### PR TITLE
test/Testing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 
 ### `Added`
 [#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Added tests and samplefile channel functions
+[#3](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/3) Added a test file for the test profile
 
 ### `Fixed`
 [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Fixed template schemas
@@ -16,3 +17,4 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 ### `Dependencies`
 
 ### `Deprecated`
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,7 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 
 ### `Deprecated`
 
+### `Removed`
+[#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Removed input_schema
+[#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Removed V1 format input. V2 is the only accepted format.
+

--- a/assets/TestSampleSheet.tsv
+++ b/assets/TestSampleSheet.tsv
@@ -1,1 +1,1 @@
-Test1	https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz
+Test1	WES	https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/assets/TestSampleSheet.tsv
+++ b/assets/TestSampleSheet.tsv
@@ -1,0 +1,1 @@
+Test1	https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,7 +22,7 @@ params {
     // Input data
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    //input  = params.pipelines_testdata_base_path + 'viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv'
+    input  = "$projectDir/assets/TestSampleSheet.tsv"
 
     // Genome references
     genome = 'R64-1-1'


### PR DESCRIPTION
Added a test samplesheet including data from https://github.com/nf-core/test-datasets which is where most nf-core pipelines get their test-data from. This will make it so the -profile test at least retrieves data similar to our own tests. 

The rest of the testing data will be given in specific module test configs.

**Note that this branch is based of SampleChannelFunctions and adds to it, do not merge until SampleChannelFunctions is merged**