### PR TITLE
Feat/sample file format + metadata propagation

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -27,6 +27,7 @@ lint:
   - .github/CONTRIBUTING.md
   - .github/PULL_REQUEST_TEMPLATE.md
   - .github/workflows/linting_comment.yml
+  - LICENSE
   multiqc_config:
   - report_comment
   nextflow_config:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 [#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Added tests and samplefile channel functions
 [#3](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/3) Added a test file for the test profile
 [#7](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/7) Added most functions and modules from previous pipeline to make it functional
+[#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9) New format "V3" is now supported. Includes metadata propagation. 
 
 ### `Fixed`
 [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Fixed template schemas
@@ -18,7 +19,7 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 ### `Dependencies`
 
 ### `Deprecated`
-
+Format "V1" and "V2" are now deprecated as of [#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9)
 ### `Removed`
 [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Removed input_schema
 [#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Removed V1 format input. V2 is the only accepted format.

--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@
 > If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.
 
 ### Samples
-The workflow will accept sample data separated by tabs. The path to the sample file must be specified with the "**input**" parameter. The second column must be either WES (Whole Exome Sequencing) or WGS (Whole Genome Sequencing)
+The workflow will accept sample data separated by commas (CSV format). The path to the sample file must be specified with the "**input**" parameter. The column names are : familyID,sampleID,sequencingType,file. The sequencing type must be either WES (Whole Exome Sequencing) or WGS (Whole Genome Sequencing).
 
-**sample.tsv**
-
-_FAMILY_ID_ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; _SEQUENCING_TYPE_ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;_Patient1_File_&nbsp; &nbsp; &nbsp;&nbsp; &nbsp;_Patient2_File_&nbsp; &nbsp; &nbsp; &nbsp;&nbsp;_Patient3_File_
-```tsv
-CONGE-XXX       WES       CONGE-XXX-01.hard-filtered.gvcf.gz   CONGE-XXX-02.hard-filtered.gvcf.gz   CONGE-XXX-03.hard-filtered.gvcf.gz
-CONGE-YYY       WES       CONGE-YYY-01.hard-filtered.gvcf.gz   CONGE-YYY-02.hard-filtered.gvcf.gz   CONGE-YYY-03.hard-filtered.gvcf.gz
+**sample.csv**
+```csv
+**familyID**,**sampleID**,**sequencingType**,**file**
+CONGE-XXX,01,WES,CONGE-XXX-01.hard-filtered.gvcf.gz
+CONGE-XXX,02,WES,CONGE-XXX-02.hard-filtered.gvcf.gz
+CONGE-XXX,03,WES,CONGE-XXX-03.hard-filtered.gvcf.gz
+CONGE-YYY,01,WGS,CONGE-YYY-01.hard-filtered.gvcf.gz
+CONGE-YYY,02,WGS,CONGE-YYY-02.hard-filtered.gvcf.gz
+CONGE-YYY,03,WGS,CONGE-YYY-03.hard-filtered.gvcf.gz
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@
 > If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.
 
 ### Samples
-The workflow will accept sample data separated by commas (CSV format). The path to the sample file must be specified with the "**input**" parameter. The column names are : familyID,sampleID,sequencingType,file. The sequencing type must be either WES (Whole Exome Sequencing) or WGS (Whole Genome Sequencing).
+The workflow will accept sample data separated by commas (CSV format). The path to the sample file must be specified with the "**input**" parameter. The column names are : familyId,sample,sequencingType,file. The sequencing type must be either WES (Whole Exome Sequencing) or WGS (Whole Genome Sequencing).
 
 **sample.csv**
 ```csv
-**familyID**,**sampleID**,**sequencingType**,**file**
+**familyId**,**sample**,**sequencingType**,**file**
 CONGE-XXX,01,WES,CONGE-XXX-01.hard-filtered.gvcf.gz
 CONGE-XXX,02,WES,CONGE-XXX-02.hard-filtered.gvcf.gz
 CONGE-XXX,03,WES,CONGE-XXX-03.hard-filtered.gvcf.gz

--- a/assets/TestSampleSheet.tsv
+++ b/assets/TestSampleSheet.tsv
@@ -1,2 +1,2 @@
-familyID,sampleID,sequencingType,file
+familyId,sample,sequencingType,file
 Family1,Test1,WES,https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/assets/TestSampleSheet.tsv
+++ b/assets/TestSampleSheet.tsv
@@ -1,1 +1,2 @@
-Test1	WES	https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz
+familyID,sampleID,sequencingType,file
+Family1,Test1,WES,https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -7,17 +7,17 @@
     "items": {
         "type": "object",
         "properties": {
-            "familyID": {
-                "type": "string",
-                "pattern": "^\\S+$",
-                "errorMessage": "familyID must be provided and cannot contain spaces",
-                "meta": ["familyID"]
-            },
-            "sampleID": {
+            "sample": {
                 "type": "string",
                 "pattern": "^\\S+$",
                 "errorMessage": "Sample ID must be provided and cannot contain spaces",
-                "meta": ["sampleID"]
+                "meta": ["sample"]
+            },
+            "familyId": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "familyId must be provided and cannot contain spaces",
+                "meta": ["familyId"]
             },
             "sequencingType": {
                 "type": "string",
@@ -26,7 +26,7 @@
                 "default": "WGS",
                 "enum": ["WGS", "WES"]
             },
-            "file": {
+            "gvcf": {
                 "errorMessage": "Filename must have extension '.gvcf' or contain 'g' and end by 'vcf'",
                 "type": "string",
                 "pattern": "^\\S+\\.g(enome.)?vcf(.gz)?$",
@@ -34,6 +34,6 @@
                 "exists": true
             }
         },
-        "required": ["familyID", "sampleID", "sequencingType","file"]
+        "required": ["familyId", "sample", "sequencingType","gvcf"]
     }
 }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/nf-core/sarek/master/assets/schema_input.json",
+    "title": "ferlab/Post-processingPipeline - params.input schema",
+    "description": "Schema for the file provided with params.input",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "familyID": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "familyID must be provided and cannot contain spaces",
+                "meta": ["familyID"]
+            },
+            "sampleID": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Sample ID must be provided and cannot contain spaces",
+                "meta": ["sampleID"]
+            },
+            "sequencingType": {
+                "type": "string",
+                "errorMessage": "SequencingType must either be 'WGS' or 'WES'. Defaults to WGS, if none is supplied.",
+                "meta": ["sequencingType"],
+                "default": "WGS",
+                "enum": ["WGS", "WES"]
+            },
+            "file": {
+                "errorMessage": "Filename must have extension '.gvcf' or contain 'g' and end by 'vcf'",
+                "type": "string",
+                "pattern": "^\\S+\\.g(enome.)?vcf(.gz)?$",
+                "format": "file-path",
+                "exists": true
+            }
+        },
+        "required": ["familyID", "sampleID", "sequencingType","file"]
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@
 
 ## Samplesheet input
 
-You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use the --input parameter to specify its location. The samplesheet has to be a tab-separated file (.tsv) with the first column being the family ID and the second being the sequencing type (either Whole Genome Sequencing (WGS) or Whole Exome Sequencing (WES)). Use the following columns to supply the paths to the gvcfs files for the same familyID. 
+You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use the --input parameter to specify its location. The samplesheet has to be a tab-separated file (.tsv) with the first column being the family ID and the second being the sequencing type (either Whole Genome Sequencing (WGS) or Whole Exome Sequencing (WES)). Use the following columns to supply the paths to the gvcfs files for the same familyId. 
 
 ```bash
 --input '[path to samplesheet file]'

--- a/main.nf
+++ b/main.nf
@@ -78,7 +78,7 @@ workflow {
     // WORKFLOW: Run main workflow
     //
     FERLAB_POSTPROCESSING (
-        params.input
+        PIPELINE_INITIALISATION.out.samplesheet
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,6 @@ workflow {
         params.outdir,
         params.input
     )
-
     //
     // WORKFLOW: Run main workflow
     //

--- a/modules/local/hardFilter.nf
+++ b/modules/local/hardFilter.nf
@@ -2,11 +2,11 @@ process hardFiltering {
     label 'medium'
 
     input:
-    tuple val(prefixId), path(vcf)
+    tuple val(prefixId), val(meta), path(vcf)
     val(filters)
 
     output:
-    tuple val(prefixId), path("*.hardfilter.vcf.gz*")
+    tuple val(prefixId), val(meta), path("*.hardfilter.vcf.gz*")
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/local/hardFilter.nf
+++ b/modules/local/hardFilter.nf
@@ -2,13 +2,14 @@ process hardFiltering {
     label 'medium'
 
     input:
-    tuple val(prefixId), val(meta), path(vcf)
+    tuple val(meta), path(vcf)
     val(filters)
 
     output:
-    tuple val(prefixId), val(meta), path("*.hardfilter.vcf.gz*")
+    tuple val(meta), path("*.hardfilter.vcf.gz*")
 
     script:
+    def prefixId = meta.familyId
     def args = task.ext.args ?: ''
     def argsjava = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
@@ -32,6 +33,7 @@ process hardFiltering {
         $args
     """
     stub:
+    def prefixId = meta.familyId
     """
     touch ${prefixId}.hardfilter.vcf.gz
     """

--- a/modules/local/vep.nf
+++ b/modules/local/vep.nf
@@ -4,13 +4,14 @@ process splitMultiAllelics{
     container 'staphb/bcftools'
     
     input:
-    tuple val(familyId), val(meta), path(vcfFile)
+    tuple val(meta), path(vcfFile)
     path referenceGenome
 
     output:
-    tuple val(familyId), val(meta), path("*splitted.vcf*")
+    tuple val(meta), path("*splitted.vcf*")
 
     script:
+    def familyId = meta.familyId
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
     """
     set -e
@@ -21,6 +22,7 @@ process splitMultiAllelics{
     """
     
     stub:
+    def familyId = meta.familyId
     """
     touch ${familyId}.splitted.vcf.gz
     touch ${familyId}.splitted.vcf.gz.tbi
@@ -33,14 +35,15 @@ process vep {
     publishDir "${params.outdir}", mode: 'copy'
 
     input:
-    tuple val(familyId), val(meta), path(vcfFile)
+    tuple val(meta), path(vcfFile)
     path referenceGenome
     path vepCache
 
     output:
-    tuple val(familyId), val(meta), path("*vep.vcf.gz")
+    tuple val(meta), path("*vep.vcf.gz")
 
     script:
+    def familyId = meta.familyId
     def args = task.ext.args ?: ''
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
     """
@@ -69,6 +72,7 @@ process vep {
     """
 
     stub:
+    def familyId = meta.familyId
     """
     touch variants.${familyId}.vep.vcf.gz
     """
@@ -80,7 +84,7 @@ process tabix {
     publishDir "${params.outdir}", mode: 'copy'
 
     input:
-    tuple val(familyId), val(meta), path(vcfFile)
+    tuple val(meta), path(vcfFile)
 
     output:
     path "*.tbi"

--- a/modules/local/vep.nf
+++ b/modules/local/vep.nf
@@ -4,11 +4,11 @@ process splitMultiAllelics{
     container 'staphb/bcftools'
     
     input:
-    tuple val(familyId), path(vcfFile)
+    tuple val(familyId), val(meta), path(vcfFile)
     path referenceGenome
 
     output:
-    tuple val(familyId), path("*splitted.vcf*")
+    tuple val(familyId), val(meta), path("*splitted.vcf*")
 
     script:
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
@@ -33,12 +33,12 @@ process vep {
     publishDir "${params.outdir}", mode: 'copy'
 
     input:
-    tuple val(familyId), path(vcfFile)
+    tuple val(familyId), val(meta), path(vcfFile)
     path referenceGenome
     path vepCache
 
     output:
-    tuple val(familyId), path("*vep.vcf.gz")
+    tuple val(familyId), val(meta), path("*vep.vcf.gz")
 
     script:
     def args = task.ext.args ?: ''
@@ -80,7 +80,7 @@ process tabix {
     publishDir "${params.outdir}", mode: 'copy'
 
     input:
-    tuple val(familyId), path(vcfFile)
+    tuple val(familyId), val(meta), path(vcfFile)
 
     output:
     path "*.tbi"

--- a/modules/local/vqsr.nf
+++ b/modules/local/vqsr.nf
@@ -9,12 +9,12 @@ process variantRecalibratorSNP {
 
 
     input:
-    tuple val(prefix), path(vcf)
+    tuple val(prefix), val(meta), path(vcf)
     path referenceGenome
     path broadResource
 
     output:
-    tuple val(prefix), path("*.recal*"), path("*.tranches")
+    tuple val(prefix), val(meta), path("*.recal*"), path("*.tranches")
     
     script:
     def args = task.ext.args ?: ''
@@ -69,12 +69,12 @@ process variantRecalibratorIndel {
 
 
     input:
-    tuple val(prefix), path(vcf)
+    tuple val(prefix), val(meta), path(vcf)
     path referenceGenome
     path broadResource
 
     output:
-    tuple val(prefix), path("*.recal*"), path("*.tranches")
+    tuple val(prefix), val(meta), path("*.recal*"), path("*.tranches")
     
     script:
     def args = task.ext.args ?: ''
@@ -124,10 +124,10 @@ process applyVQSRSNP {
     
 
     input:
-    tuple val(prefix), path(recal), path(tranches), path(vcf)
+    tuple val(prefix),val(meta), path(recal), path(tranches), path(vcf)
 
     output:
-    tuple val(prefix), path("*.snp.vqsr_${params.TSfilterSNP}.vcf.gz*")
+    tuple val(prefix), val(meta),path("*.snp.vqsr_${params.TSfilterSNP}.vcf.gz*")
 
     script:
     def args = task.ext.args ?: ''
@@ -171,10 +171,10 @@ process applyVQSRIndel {
     container 'broadinstitute/gatk'
 
     input:
-    tuple val(prefix), path(recal), path(tranches), path(vcf)
+    tuple val(prefix), val(meta), path(recal), path(tranches), path(vcf)
 
     output:
-    tuple val(prefix), path("*.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz*")
+    tuple val(prefix), val(meta), path("*.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz*")
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/local/vqsr.nf
+++ b/modules/local/vqsr.nf
@@ -9,14 +9,15 @@ process variantRecalibratorSNP {
 
 
     input:
-    tuple val(prefix), val(meta), path(vcf)
+    tuple val(meta), path(vcf)
     path referenceGenome
     path broadResource
 
     output:
-    tuple val(prefix), val(meta), path("*.recal*"), path("*.tranches")
+    tuple val(meta), path("*.recal*"), path("*.tranches")
     
     script:
+    def prefix = meta.familyId
     def args = task.ext.args ?: ''
     def argsjava = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
@@ -53,6 +54,7 @@ process variantRecalibratorSNP {
     """
 
     stub:
+    def prefix = meta.familyId
     """
     touch ${prefix}.recal
     touch ${prefix}.tranches
@@ -69,14 +71,15 @@ process variantRecalibratorIndel {
 
 
     input:
-    tuple val(prefix), val(meta), path(vcf)
+    tuple val(meta), path(vcf)
     path referenceGenome
     path broadResource
 
     output:
-    tuple val(prefix), val(meta), path("*.recal*"), path("*.tranches")
+    tuple val(meta), path("*.recal*"), path("*.tranches")
     
     script:
+    def prefix = meta.familyId
     def args = task.ext.args ?: ''
     def argsjava = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
@@ -110,6 +113,7 @@ process variantRecalibratorIndel {
     """
 
     stub:
+    def prefix = meta.familyId
     """
     touch ${prefix}.recal
     touch ${prefix}.tranches
@@ -124,12 +128,13 @@ process applyVQSRSNP {
     
 
     input:
-    tuple val(prefix),val(meta), path(recal), path(tranches), path(vcf)
+    tuple val(meta), path(recal), path(tranches), path(vcf)
 
     output:
-    tuple val(prefix), val(meta),path("*.snp.vqsr_${params.TSfilterSNP}.vcf.gz*")
+    tuple val(meta),path("*.snp.vqsr_${params.TSfilterSNP}.vcf.gz*")
 
     script:
+    def prefix = meta.familyId
     def args = task.ext.args ?: ''
     def argsjava = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
@@ -156,6 +161,7 @@ process applyVQSRSNP {
         $args
     """
     stub:
+    def prefix = meta.familyId
     """
     touch ${prefix}.snp.vqsr_${params.TSfilterSNP}.vcf.gz
     """
@@ -171,12 +177,13 @@ process applyVQSRIndel {
     container 'broadinstitute/gatk'
 
     input:
-    tuple val(prefix), val(meta), path(recal), path(tranches), path(vcf)
+    tuple val(meta), path(recal), path(tranches), path(vcf)
 
     output:
-    tuple val(prefix), val(meta), path("*.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz*")
+    tuple val(meta), path("*.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz*")
 
     script:
+    def prefix = meta.familyId
     def args = task.ext.args ?: ''
     def argsjava = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
@@ -203,6 +210,7 @@ process applyVQSRIndel {
         $args
     """
     stub:
+    def prefix = meta.familyId
     """
     touch ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz
     """

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -16,11 +16,12 @@
           "type": "string",
           "format": "file-path",
           "exists": true,
-          "mimetype": "text/tsv",
-          "pattern": "^\\S+\\.tsv$",
-          "description": "Path to the .tsv sample file, of format V1 or V2, containing the Family ID and path to GVCF files",
+          "mimetype": "text/csv",
+          "pattern": "^\\S+\\.csv$",
+          "description": "Path to the .csv sample file containing the Family ID, sample ID, sequencing Type and path to GVCF files",
           "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.",
-          "fa_icon": "fas fa-file-csv"
+          "fa_icon": "fas fa-file-csv",
+          "schema": "assets/schema_input.json"
         },
         "outdir": {
           "type": "string",
@@ -60,12 +61,6 @@
           "description": "Directory containing the referenceGenomeFasta",
           "help_text": "Contains the path to the directory that contains the reference fasta genome.",
           "format": "directory-path"
-        },
-        "referenceGenomeFasta": {
-          "type": "string",
-          "description": "Name of the fasta file for the genome",
-          "help_text": "Name of the fasta file for the genome we usually apply \"Homo_sapiens_assembly38.fasta\"",
-          "format": "file-path"
         },
         "referenceGenomeFasta": {
           "type": "string",
@@ -243,6 +238,13 @@
           "default": "https://raw.githubusercontent.com/nf-core/test-datasets/",
           "hidden": true
         },
+        "sequencingType": {
+          "type": "string",
+          "default": "WGS",
+          "description": "\"Either \\\"WGS\\\" for Whole Genome Sequencing or \\\"WES\\\" for Whole Exome Sequencing\"",
+          "help_text": "\"Either \\\"WGS\\\" for Whole Genome Sequencing or \\\"WES\\\" for Whole Exome Sequencing\"",
+          "enum": ["WGS", "WES"]
+        },
         "TSfilterSNP": {
           "type": "string",
           "default": "99",
@@ -256,7 +258,8 @@
           "description": "Truth-sensitivity filter level for Indels"
         },
         "hardFilters": {
-          "type": "array",
+          "type": "string",
+          "default": "[[name:'QD2', expression:'QD < 2.0'], [name:'QD1', expression:'QD < 1.0'], [name:'QUAL30', expression:'QUAL < 30.0'], [name:'SOR3', expression:'SOR > 3.0'], [name:'FS60', expression:'FS > 60.0'], [name:'MQ40', expression:'MQ < 40.0'], [name:'MQRankSum-12.5', expression:'MQRankSum < -12.5'], [name:'ReadPosRankSum-8', expression:'ReadPosRankSum < -8.0']]",
           "description": "Parameters for Hard-Filtering",
           "help_text": "Parameters for Hard-Filtering. Must be an array containing each desired filter. Each filter must be formatted with the desired name and expression, for example\\n[[name: 'QD1', expression: 'QD < 1.0'],[name: 'QD2', expression: 'QD < 2.0]]"
         }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -258,8 +258,7 @@
           "description": "Truth-sensitivity filter level for Indels"
         },
         "hardFilters": {
-          "type": "string",
-          "default": "[[name:'QD2', expression:'QD < 2.0'], [name:'QD1', expression:'QD < 1.0'], [name:'QUAL30', expression:'QUAL < 30.0'], [name:'SOR3', expression:'SOR > 3.0'], [name:'FS60', expression:'FS > 60.0'], [name:'MQ40', expression:'MQ < 40.0'], [name:'MQRankSum-12.5', expression:'MQRankSum < -12.5'], [name:'ReadPosRankSum-8', expression:'ReadPosRankSum < -8.0']]",
+          "type": "array",
           "description": "Parameters for Hard-Filtering",
           "help_text": "Parameters for Hard-Filtering. Must be an array containing each desired filter. Each filter must be formatted with the desired name and expression, for example\\n[[name: 'QD1', expression: 'QD < 1.0'],[name: 'QD2', expression: 'QD < 2.0]]"
         }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -238,13 +238,6 @@
           "default": "https://raw.githubusercontent.com/nf-core/test-datasets/",
           "hidden": true
         },
-        "sequencingType": {
-          "type": "string",
-          "default": "WGS",
-          "description": "\"Either \\\"WGS\\\" for Whole Genome Sequencing or \\\"WES\\\" for Whole Exome Sequencing\"",
-          "help_text": "\"Either \\\"WGS\\\" for Whole Genome Sequencing or \\\"WES\\\" for Whole Exome Sequencing\"",
-          "enum": ["WGS", "WES"]
-        },
         "TSfilterSNP": {
           "type": "string",
           "default": "99",

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -85,7 +85,7 @@ workflow PIPELINE_INITIALISATION {
             meta, file ->
             [meta.familyID, [meta, file]]
         }
-        .tap{ch_sample_simple}
+        .tap{ch_sample_simple} //Save this channel to join later
         .groupTuple()
         .map{
             family_sampleID, ch_items ->
@@ -93,7 +93,7 @@ workflow PIPELINE_INITIALISATION {
         }
         .combine(ch_sample_simple,by:0)
         .map {
-            id,size,metasfile ->
+            id,size,metasfile -> //include sample count in meta
                 [meta:
                     [familyId: id,
                     sampleId: metasfile[0].sampleID,
@@ -106,23 +106,6 @@ workflow PIPELINE_INITIALISATION {
     emit:
     samplesheet = ch_samplesheet
     versions    = ch_versions
-
-    /*
-    Channel.fromPath(file("$params.input"))
-        .splitCsv(sep: '\t', strip: true)
-        .map{rowMapperV2(it)}
-        .flatMap { it ->
-            return it.files.collect{f -> [familyId: it.familyId, sequencingType: it.sequencingType, size: it.files.size(), file: f]};
-        }.multiMap { it ->
-            meta: tuple(it.familyId, [size: it.size, sequencingType: it.sequencingType])
-            files: tuple(it.familyId, file("${it.file}*"))
-        }
-        .set { ch_sampleChannel}
-        emit:
-        sampleFiles = ch_sampleChannel.files
-        sampleMeta = ch_sampleChannel.meta
-        versions = ch_versions
-        */
 }
 
 /*

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -96,15 +96,13 @@ workflow PIPELINE_INITIALISATION {
             id,size,metasfile ->
                 [meta:
                     [familyId: id,
-                    sampleID: metasfile[0].sampleID,
+                    sampleId: metasfile[0].sampleID,
                     sequencingType: metasfile[0].sequencingType,
                     sampleSize: size],
                 file: metasfile[1]
                 ]
         }
-        .view{"final: ${it}"}
         .set {ch_samplesheet}
-    ch_samplesheet.view{"Channel: ${it}"}
     emit:
     samplesheet = ch_samplesheet
     versions    = ch_versions

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -95,8 +95,8 @@ workflow PIPELINE_INITIALISATION {
         .map {
             id,size,metasfile -> //include sample count in meta
                 [
-                    meta: metasfile[0] + [sampleSize: size],
-                    file: metasfile[1]
+                    metasfile[0] + [sampleSize: size], //meta
+                    metasfile[1]                       //file
                 ]
         }.set {ch_samplesheet}
     emit:

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -83,26 +83,22 @@ workflow PIPELINE_INITIALISATION {
         .fromSamplesheet("input")
         .map {
             meta, file ->
-            [meta.familyID, [meta, file]]
+            [meta.familyId, [meta, file]]
         }
         .tap{ch_sample_simple} //Save this channel to join later
         .groupTuple()
         .map{
-            family_sampleID, ch_items ->
-            [family_sampleID, ch_items.size()]
+            familyId, ch_items ->
+            [familyId, ch_items.size()]
         }
         .combine(ch_sample_simple,by:0)
         .map {
             id,size,metasfile -> //include sample count in meta
-                [meta:
-                    [familyId: id,
-                    sampleId: metasfile[0].sampleID,
-                    sequencingType: metasfile[0].sequencingType,
-                    sampleSize: size],
-                file: metasfile[1]
+                [
+                    meta: metasfile[0] + [sampleSize: size],
+                    file: metasfile[1]
                 ]
-        }
-        .set {ch_samplesheet}
+        }.set {ch_samplesheet}
     emit:
     samplesheet = ch_samplesheet
     versions    = ch_versions

--- a/subworkflows/local/vqsr/main.nf
+++ b/subworkflows/local/vqsr/main.nf
@@ -10,19 +10,19 @@ All output files will be prefixed with the given prefixId.
 */
 workflow VQSR {
     take:
-        input // channel: (val(prefixId),  [.vcf.gz, .vcf.gz.tbi])
-
+        input // channel: (val(prefixId), va(meta),  [.vcf.gz, .vcf.gz.tbi])
     main:
+        ch_input = input.map{id,metas,files -> [id,files]}
         referenceGenome = file(params.referenceGenome)
         broad = file(params.broad)
 
 
         outputSNP = variantRecalibratorSNP(input, referenceGenome, broad)
-            | join(input)
+            | join(ch_input)
             | applyVQSRSNP
-
+        ch_outputSNP = outputSNP.map{id,metas,files -> [id,files]}
         output = variantRecalibratorIndel(input, referenceGenome, broad)
-            | join(outputSNP)
+            | join(ch_outputSNP)
             | applyVQSRIndel
 
     emit:

--- a/subworkflows/local/vqsr/main.nf
+++ b/subworkflows/local/vqsr/main.nf
@@ -4,7 +4,7 @@ include { variantRecalibratorIndel; variantRecalibratorSNP; applyVQSRIndel; appl
 Filter out probable artifacts from the callset using the Variant Quality Score Recalibration (VQSR) procedure
 
 The input and output formats are the same:
-    Input: (prefixId,  [some.file.vcf.gz, some.file.vcf.gz.tbi])
+    Input: ([meta],  [some.file.vcf.gz, some.file.vcf.gz.tbi])
 
 All output files will be prefixed with the given prefixId.
 */
@@ -24,5 +24,5 @@ workflow VQSR {
             | applyVQSRIndel
 
     emit:
-        output // channel: (val(prefixId),  [.vcf.gz, .vcf.gz.tbi])
+        output // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
 }

--- a/subworkflows/local/vqsr/main.nf
+++ b/subworkflows/local/vqsr/main.nf
@@ -10,19 +10,17 @@ All output files will be prefixed with the given prefixId.
 */
 workflow VQSR {
     take:
-        input // channel: (val(prefixId), va(meta),  [.vcf.gz, .vcf.gz.tbi])
+        input // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
     main:
-        ch_input = input.map{id,metas,files -> [id,files]}
         referenceGenome = file(params.referenceGenome)
         broad = file(params.broad)
 
 
         outputSNP = variantRecalibratorSNP(input, referenceGenome, broad)
-            | join(ch_input)
+            | join(input)
             | applyVQSRSNP
-        ch_outputSNP = outputSNP.map{id,metas,files -> [id,files]}
         output = variantRecalibratorIndel(input, referenceGenome, broad)
-            | join(ch_outputSNP)
+            | join(outputSNP)
             | applyVQSRIndel
 
     emit:

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -210,8 +210,8 @@ workflow POSTPROCESSING {
                     .groupTuple()
                     .map{ familyId, metas, files -> //now that samples are grouped together, we no longer follow sample in meta
                         [
-                            meta: metas[0].findAll{it.key != "sample"},
-                            files: files.flatten()]}
+                            metas[0].findAll{it.key != "sample"}, //meta
+                            files.flatten()]}                     //files
     //Using 2 as threshold because we have 2 files per patient (gcvf.gz, gvcf.gz.tbi)
     filtered_one = filtered.filter{it.meta.sampleSize == 1}
     filtered_mult = filtered.filter{it.meta.sampleSize > 1}

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -213,8 +213,8 @@ workflow POSTPROCESSING {
                             metas[0].findAll{it.key != "sample"}, //meta
                             files.flatten()]}                     //files
     //Using 2 as threshold because we have 2 files per patient (gcvf.gz, gvcf.gz.tbi)
-    filtered_one = filtered.filter{it.meta.sampleSize == 1}
-    filtered_mult = filtered.filter{it.meta.sampleSize > 1}
+    filtered_one = filtered.filter{it[0].sampleSize == 1}
+    filtered_mult = filtered.filter{it[0].sampleSize > 1}
     //Combine per-sample gVCF files into a multi-sample gVCF file
     DB = importGVCF(filtered_mult, referenceGenome,broad)
                     .concat(filtered_one)

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -53,23 +53,19 @@ process excludeMNPs {
     def familyId = meta.familyId
     def sampleId = meta.sampleId
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
-    def uuid = UUID.randomUUID().toString()
-    // --regions chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY
-    // bcftools view --exclude-type mnps  ${exactGvcfFile} -O z -o ${familyId}.${uuid}.filtered.gvcf.gz
     """
     set -e
     echo $familyId > file
-    bcftools filter -e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"' ${exactGvcfFile} | bcftools norm -d any -O z -o ${familyId}.${sampleId}.${uuid}.filtered.vcf.gz
-    bcftools index -t ${familyId}.${sampleId}.${uuid}.filtered.vcf.gz
+    bcftools filter -e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"' ${exactGvcfFile} | bcftools norm -d any -O z -o ${familyId}.${sampleId}.filtered.vcf.gz
+    bcftools index -t ${familyId}.${sampleId}.filtered.vcf.gz
     """
     stub:
     def familyId = meta.familyId
     def sampleId = meta.sampleId
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
-    def uuid = UUID.randomUUID().toString()
     """
-    touch ${familyId}.${sampleId}.${uuid}.filtered.vcf.gz
-    touch ${familyId}.${sampleId}.${uuid}.filtered.vcf.gz.tbi
+    touch ${familyId}.${sampleId}.filtered.vcf.gz
+    touch ${familyId}.${sampleId}.filtered.vcf.gz.tbi
     """
 
 }

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -224,7 +224,7 @@ workflow POSTPROCESSING {
     filtered = excludeMNPs(ch_samplesheet)
                     .map{meta, files -> tuple( groupKey(meta.familyId, meta.sampleSize),meta,files)}
                     .groupTuple()
-                    .map{ familyId, meta, files -> 
+                    .map{ familyId, meta, files -> //now that samples are grouped together, we no longer follow sampleID in meta
                         [familyId: familyId, 
                             meta:[familyId: meta[0].familyId,
                             sequencingType: meta[0].sequencingType,


### PR DESCRIPTION
Changed the expected input format of the samplesheet as discussed on [notion](https://www.notion.so/ferlab/Nf-core-guidelines-43b08da49e8f49b2968f17a34adc783a).

We now expect a CSV file, with exactly 5 columns per sample (header required): 

|familyID|sampleID|sequencingType|file|
|---------|---|---|---|

A metadata block (familyID, sampleID, sequencingType, number of samples) now follow the channel for each function across the pipeline. 

The pipeline still works with the same functions as before, we still need to separate them in modules.

