### PR TITLE
Feat/exclude_mnps into modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
 
         # Using the stub mode until our test data setup is ready
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -stub -profile test,docker
+          nextflow run ${GITHUB_WORKSPACE} -stub -profile test,docker --input assets/TestSampleSheet.csv

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testing/
 testing*
 *.pyc
 localTest/
+data-test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 - [#3](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/3) Added a test file for the test profile
 - [#7](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/7) Added most functions and modules from previous pipeline to make it functional
 - [#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9) New format "V3" is now supported. Includes metadata propagation. 
-
+- [#10](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/10) Converted the exclude_MNPs function into a nf-core subworkflow containing 2 nf-core modules. 
 ### `Fixed`
 - [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Fixed template schemas
 - [#13](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/13) Run test in stub mode in GitLab workflow with necessary adjustments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-
 - [#3](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/3) Added a test file for the test profile
 - [#7](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/7) Added most functions and modules from previous pipeline to make it functional
 - [#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9) New format "V3" is now supported. Includes metadata propagation. 
-- [#10](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/10) Converted the exclude_MNPs function into a nf-core subworkflow containing 2 nf-core modules. 
+- [#10](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/10) Converted the exclude_MNPs function into a nf-core subworkflow containing 2 nf-core modules. Also added test profile test data (but it fails at VQSR for now)
 ### `Fixed`
 - [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Fixed template schemas
 - [#13](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/13) Run test in stub mode in GitLab workflow with necessary adjustments

--- a/assets/TestSampleSheet.csv
+++ b/assets/TestSampleSheet.csv
@@ -1,4 +1,3 @@
 familyId,sample,sequencingType,gvcf
 Family1,Test1,WES,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz
-Family1,Test2,WES,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz
-Family2,Test3,WGS,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz
+Family1,Test2,WGS,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -29,7 +29,7 @@
             "gvcf": {
                 "errorMessage": "Filename must have extension '.gvcf' or contain 'g' and end by 'vcf'",
                 "type": "string",
-                "pattern": "^\\S+\\.g(enome.)?vcf(.gz)?$",
+                "pattern": "^\\S+\\.(g)?(enome.)?vcf(.gz)?$",
                 "format": "file-path",
                 "exists": true
             }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,17 +18,8 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
-    withName: FASTQC {
-        ext.args = '--quiet'
-    }
+    withName: BCFTOOLS_FILTER {
+        ext.args = "-e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp" -Oz'"
 
-    withName: 'MULTIQC' {
-        ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
-        publishDir = [
-            path: { "${params.outdir}/multiqc" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
     }
-
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -19,13 +19,13 @@ process {
     ]
 
     withName: BCFTOOLS_FILTER {
-        container = 'staphb/bcftools:1.19'
-        ext.args = {'''-e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp" --write-index=tbi -Oz'''}
+        container = 'staphb/bcftools:1.20'
+        ext.args = {'-e \'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"\' -Oz --write-index=tbi'}
         ext.prefix = {meta.familyId + "." + meta.sample + ".filtered"}
     }
 
     withName: BCFTOOLS_NORM {
-        container = 'staphb/bcftools:1.19'
+        container = 'staphb/bcftools:1.20'
         ext.args = {'-c w -d all -Oz --write-index=tbi'}
         ext.prefix = {meta.familyId + "." + meta.sample + ".normalized"}
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -21,12 +21,12 @@ process {
     withName: BCFTOOLS_FILTER {
         container = 'staphb/bcftools:1.20'
         ext.args = {'-e \'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"\' -Oz --write-index=tbi'}
-        ext.prefix = {meta.familyId + "." + meta.sample + ".filtered"}
+        ext.prefix = {meta.id + ".filtered"}
     }
 
     withName: BCFTOOLS_NORM {
         container = 'staphb/bcftools:1.20'
         ext.args = {'-c w -d all -Oz --write-index=tbi'}
-        ext.prefix = {meta.familyId + "." + meta.sample + ".normalized"}
+        ext.prefix = {meta.id + ".normalized"}
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -19,7 +19,14 @@ process {
     ]
 
     withName: BCFTOOLS_FILTER {
-        ext.args = "-e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp" -Oz'"
+        container = 'staphb/bcftools:1.19'
+        ext.args = {'''-e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp" --write-index=tbi -Oz'''}
+        ext.prefix = {meta.familyId + "." + meta.sample + ".filtered"}
+    }
 
+    withName: BCFTOOLS_NORM {
+        container = 'staphb/bcftools:1.19'
+        ext.args = {'-c w -d all -Oz --write-index=tbi'}
+        ext.prefix = {meta.familyId + "." + meta.sample + ".normalized"}
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,13 +20,31 @@ params {
     max_time   = '6.h'
 
     // Input and output
-    input  = "$projectDir/assets/TestSampleSheet.csv"
-    outdir = "$projectDir/results"
-    referenceGenome = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/"
-    referenceGenomeFasta = "genome.fasta"
-    intervalsFile = "$projectDir/assets/testInterval22.txt"
-    broad = "$projectDir/data-test/reference/broad"
-    vepCache = "$projectDir/data-test/reference/annotation/.vep"
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Defines parameters and configuration settings required to run a fast and simple pipeline test.
+
+To run the pipeline in stub mode, you can use this command:
+     nextflow  run Ferlab-Ste-Justine/Post-processing-Pipeline -r main  -stub -profile test,docker
+     
+To run the pipeline without using stub mode, we have a test dataset available, 
+but it must be downloaded manually. Ask the bioinformatics team for its location.
+If you download the dataset archive (.tar.gz) and extract it at the root of this 
+repository (tar -xzf <archive file>), you should be able to run the pipeline with the
+ following command:
+     nextflow -c data-test/test.config  run  Ferlab-Ste-Justine/Post-processing-Pipeline -r main -profile test,docker --input data-test/testSampleSheet.csv
+    
+----------------------------------------------------------------------------------------
+*/
+    input  = "data-test/testSampleSheet.csv"
+    outdir = "results"
+    referenceGenome = "data-test/reference/Homo_sapiens_assembly38/chr22"
+    referenceGenomeFasta = "chr22.fa"
+    intervalsFile = "testInterval22.list"
+    broad = "data-test/reference/broad"
+    vepCache = "data-test/reference/annotation/.vep"
     hardFilters = [[name: 'QD2', expression: 'QD < 2.0'],
 		           [name: 'QD1', expression: 'QD < 1.0'],
                    [name: 'QUAL30', expression: 'QUAL < 30.0'],
@@ -35,26 +53,4 @@ params {
                    [name: 'MQ40', expression: 'MQ < 40.0'],
                    [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
                    [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']]
-
-
-    // Stub values are used for these parameters. They will be replaced with actual values when our test data setup is 
-    // ready.
-    intervalsFile = "interval_long_local.list"
-    broad = "broad"
-    referenceGenome = "reference/Genome/directory"
-    referenceGenomeFasta = "genome.fasta"
-    vepCache = "vepCache"
-}
-process {
-    withName: BCFTOOLS_FILTER {
-        container = 'staphb/bcftools:1.20'
-        ext.args = {'-e \'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"\' -Oz --write-index=tbi'}
-        ext.prefix = {meta.familyId + "." + meta.sample + ".filtered"}
-    }
-
-    withName: BCFTOOLS_NORM {
-        container = 'staphb/bcftools:1.20'
-        ext.args = {'-c w -d all -Oz --write-index=tbi'}
-        ext.prefix = {meta.familyId + "." + meta.sample + ".normalized"}
-    }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,6 +22,20 @@ params {
     // Input and output
     input  = "$projectDir/assets/TestSampleSheet.csv"
     outdir = "$projectDir/results"
+    referenceGenome = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/"
+    referenceGenomeFasta = "genome.fasta"
+    intervalsFile = "$projectDir/assets/testInterval22.txt"
+    broad = "$projectDir/data-test/reference/broad"
+    vepCache = "$projectDir/data-test/reference/annotation/.vep"
+    hardFilters = [[name: 'QD2', expression: 'QD < 2.0'],
+		           [name: 'QD1', expression: 'QD < 1.0'],
+                   [name: 'QUAL30', expression: 'QUAL < 30.0'],
+                   [name: 'SOR3', expression: 'SOR > 3.0'],
+                   [name: 'FS60', expression: 'FS > 60.0'],
+                   [name: 'MQ40', expression: 'MQ < 40.0'],
+                   [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
+                   [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']]
+
 
     // Stub values are used for these parameters. They will be replaced with actual values when our test data setup is 
     // ready.
@@ -30,4 +44,17 @@ params {
     referenceGenome = "reference/Genome/directory"
     referenceGenomeFasta = "genome.fasta"
     vepCache = "vepCache"
+}
+process {
+    withName: BCFTOOLS_FILTER {
+        container = 'staphb/bcftools:1.20'
+        ext.args = {'-e \'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"\' -Oz --write-index=tbi'}
+        ext.prefix = {meta.familyId + "." + meta.sample + ".filtered"}
+    }
+
+    withName: BCFTOOLS_NORM {
+        container = 'staphb/bcftools:1.20'
+        ext.args = {'-c w -d all -Oz --write-index=tbi'}
+        ext.prefix = {meta.familyId + "." + meta.sample + ".normalized"}
+    }
 }

--- a/modules.json
+++ b/modules.json
@@ -5,6 +5,11 @@
     "https://github.com/nf-core/modules.git": {
       "modules": {
         "nf-core": {
+          "bcftools/filter": {
+            "branch": "master",
+            "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
+            "installed_by": ["modules"]
+          },
           "fastqc": {
             "branch": "master",
             "git_sha": "285a50500f9e02578d90b3ce6382ea3c30216acd",

--- a/modules.json
+++ b/modules.json
@@ -1,46 +1,65 @@
 {
-  "name": "ferlab/postprocessing",
-  "homePage": "https://github.com/ferlab/postprocessing",
-  "repos": {
-    "https://github.com/nf-core/modules.git": {
-      "modules": {
-        "nf-core": {
-          "bcftools/filter": {
-            "branch": "master",
-            "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
-            "installed_by": ["modules"]
-          },
-          "fastqc": {
-            "branch": "master",
-            "git_sha": "285a50500f9e02578d90b3ce6382ea3c30216acd",
-            "installed_by": ["modules"]
-          },
-          "multiqc": {
-            "branch": "master",
-            "git_sha": "b7ebe95761cd389603f9cc0e0dc384c0f663815a",
-            "installed_by": ["modules"]
-          }
+    "name": "ferlab/postprocessing",
+    "homePage": "https://github.com/ferlab/postprocessing",
+    "repos": {
+        "https://github.com/nf-core/modules.git": {
+            "modules": {
+                "nf-core": {
+                    "bcftools/filter": {
+                        "branch": "master",
+                        "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "bcftools/norm": {
+                        "branch": "master",
+                        "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "fastqc": {
+                        "branch": "master",
+                        "git_sha": "285a50500f9e02578d90b3ce6382ea3c30216acd",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "multiqc": {
+                        "branch": "master",
+                        "git_sha": "b7ebe95761cd389603f9cc0e0dc384c0f663815a",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    }
+                }
+            },
+            "subworkflows": {
+                "nf-core": {
+                    "utils_nextflow_pipeline": {
+                        "branch": "master",
+                        "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
+                        "installed_by": [
+                            "subworkflows"
+                        ]
+                    },
+                    "utils_nfcore_pipeline": {
+                        "branch": "master",
+                        "git_sha": "92de218a329bfc9a9033116eb5f65fd270e72ba3",
+                        "installed_by": [
+                            "subworkflows"
+                        ]
+                    },
+                    "utils_nfvalidation_plugin": {
+                        "branch": "master",
+                        "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
+                        "installed_by": [
+                            "subworkflows"
+                        ]
+                    }
+                }
+            }
         }
-      },
-      "subworkflows": {
-        "nf-core": {
-          "utils_nextflow_pipeline": {
-            "branch": "master",
-            "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-            "installed_by": ["subworkflows"]
-          },
-          "utils_nfcore_pipeline": {
-            "branch": "master",
-            "git_sha": "92de218a329bfc9a9033116eb5f65fd270e72ba3",
-            "installed_by": ["subworkflows"]
-          },
-          "utils_nfvalidation_plugin": {
-            "branch": "master",
-            "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-            "installed_by": ["subworkflows"]
-          }
-        }
-      }
     }
-  }
 }

--- a/modules.json
+++ b/modules.json
@@ -1,65 +1,51 @@
 {
-    "name": "ferlab/postprocessing",
-    "homePage": "https://github.com/ferlab/postprocessing",
-    "repos": {
-        "https://github.com/nf-core/modules.git": {
-            "modules": {
-                "nf-core": {
-                    "bcftools/filter": {
-                        "branch": "master",
-                        "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "bcftools/norm": {
-                        "branch": "master",
-                        "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "fastqc": {
-                        "branch": "master",
-                        "git_sha": "285a50500f9e02578d90b3ce6382ea3c30216acd",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "multiqc": {
-                        "branch": "master",
-                        "git_sha": "b7ebe95761cd389603f9cc0e0dc384c0f663815a",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    }
-                }
-            },
-            "subworkflows": {
-                "nf-core": {
-                    "utils_nextflow_pipeline": {
-                        "branch": "master",
-                        "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
-                    },
-                    "utils_nfcore_pipeline": {
-                        "branch": "master",
-                        "git_sha": "92de218a329bfc9a9033116eb5f65fd270e72ba3",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
-                    },
-                    "utils_nfvalidation_plugin": {
-                        "branch": "master",
-                        "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
-                    }
-                }
-            }
+  "name": "ferlab/postprocessing",
+  "homePage": "https://github.com/ferlab/postprocessing",
+  "repos": {
+    "https://github.com/nf-core/modules.git": {
+      "modules": {
+        "nf-core": {
+          "bcftools/filter": {
+            "branch": "master",
+            "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
+            "installed_by": ["modules"]
+          },
+          "bcftools/norm": {
+            "branch": "master",
+            "git_sha": "33ef773a7ea36e88323902f63662aa53c9b88988",
+            "installed_by": ["modules"]
+          },
+          "fastqc": {
+            "branch": "master",
+            "git_sha": "285a50500f9e02578d90b3ce6382ea3c30216acd",
+            "installed_by": ["modules"]
+          },
+          "multiqc": {
+            "branch": "master",
+            "git_sha": "b7ebe95761cd389603f9cc0e0dc384c0f663815a",
+            "installed_by": ["modules"]
+          }
         }
+      },
+      "subworkflows": {
+        "nf-core": {
+          "utils_nextflow_pipeline": {
+            "branch": "master",
+            "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
+            "installed_by": ["subworkflows"]
+          },
+          "utils_nfcore_pipeline": {
+            "branch": "master",
+            "git_sha": "92de218a329bfc9a9033116eb5f65fd270e72ba3",
+            "installed_by": ["subworkflows"]
+          },
+          "utils_nfvalidation_plugin": {
+            "branch": "master",
+            "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
+            "installed_by": ["subworkflows"]
+          }
+        }
+      }
     }
+  }
 }

--- a/modules/local/vep.nf
+++ b/modules/local/vep.nf
@@ -15,17 +15,17 @@ process splitMultiAllelics{
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
     """
     set -e
-    echo $familyId > file
-    bcftools annotate -x FORMAT/PRI ${exactVcfFile} | bcftools norm -c w -m -any -f $referenceGenome/${params.referenceGenomeFasta} --old-rec-tag OLD_RECORD --output-type z --output ${familyId}.normed.vcf.gz  
-    bcftools view --min-ac 1 --output-type z --output ${familyId}.splitted.vcf.gz ${familyId}.normed.vcf.gz
-    bcftools index -t ${familyId}.splitted.vcf.gz
+    echo $familyID > file
+    bcftools annotate -x FORMAT/PRI ${exactVcfFile} | bcftools norm -c w -m -any -f $referenceGenome/${params.referenceGenomeFasta} --old-rec-tag OLD_RECORD --output-type z --output ${familyID}.normed.vcf.gz  
+    bcftools view --min-ac 1 --output-type z --output ${familyID}.splitted.vcf.gz ${familyID}.normed.vcf.gz
+    bcftools index -t ${familyID}.splitted.vcf.gz
     """
     
     stub:
     def familyId = meta.familyId
     """
-    touch ${familyId}.splitted.vcf.gz
-    touch ${familyId}.splitted.vcf.gz.tbi
+    touch ${familyID}.splitted.vcf.gz
+    touch ${familyID}.splitted.vcf.gz.tbi
     """
 }
 
@@ -56,7 +56,7 @@ process vep {
         --input_file $exactVcfFile \\
         --format vcf \\
         --vcf \\
-        --output_file variants.${familyId}.vep.vcf.gz \\
+        --output_file variants.${familyID}.vep.vcf.gz \\
         --compress_output bgzip \\
         --xref_refseq \\
         --variant_class \\
@@ -74,7 +74,7 @@ process vep {
     stub:
     def familyId = meta.familyId
     """
-    touch variants.${familyId}.vep.vcf.gz
+    touch variants.${familyID}.vep.vcf.gz
     """
 }
 

--- a/modules/local/vep.nf
+++ b/modules/local/vep.nf
@@ -15,17 +15,17 @@ process splitMultiAllelics{
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
     """
     set -e
-    echo $familyID > file
-    bcftools annotate -x FORMAT/PRI ${exactVcfFile} | bcftools norm -c w -m -any -f $referenceGenome/${params.referenceGenomeFasta} --old-rec-tag OLD_RECORD --output-type z --output ${familyID}.normed.vcf.gz  
-    bcftools view --min-ac 1 --output-type z --output ${familyID}.splitted.vcf.gz ${familyID}.normed.vcf.gz
-    bcftools index -t ${familyID}.splitted.vcf.gz
+    echo $familyId > file
+    bcftools annotate -x FORMAT/PRI ${exactVcfFile} | bcftools norm -c w -m -any -f $referenceGenome/${params.referenceGenomeFasta} --old-rec-tag OLD_RECORD --output-type z --output ${familyId}.normed.vcf.gz  
+    bcftools view --min-ac 1 --output-type z --output ${familyId}.splitted.vcf.gz ${familyId}.normed.vcf.gz
+    bcftools index -t ${familyId}.splitted.vcf.gz
     """
     
     stub:
     def familyId = meta.familyId
     """
-    touch ${familyID}.splitted.vcf.gz
-    touch ${familyID}.splitted.vcf.gz.tbi
+    touch ${familyId}.splitted.vcf.gz
+    touch ${familyId}.splitted.vcf.gz.tbi
     """
 }
 
@@ -56,7 +56,7 @@ process vep {
         --input_file $exactVcfFile \\
         --format vcf \\
         --vcf \\
-        --output_file variants.${familyID}.vep.vcf.gz \\
+        --output_file variants.${familyId}.vep.vcf.gz \\
         --compress_output bgzip \\
         --xref_refseq \\
         --variant_class \\
@@ -74,7 +74,7 @@ process vep {
     stub:
     def familyId = meta.familyId
     """
-    touch variants.${familyID}.vep.vcf.gz
+    touch variants.${familyId}.vep.vcf.gz
     """
 }
 

--- a/modules/nf-core/bcftools/filter/environment.yml
+++ b/modules/nf-core/bcftools/filter/environment.yml
@@ -1,0 +1,7 @@
+name: bcftools_filter
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bcftools=1.20

--- a/modules/nf-core/bcftools/filter/main.nf
+++ b/modules/nf-core/bcftools/filter/main.nf
@@ -1,0 +1,73 @@
+process BCFTOOLS_FILTER {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bcftools:1.20--h8b25389_0':
+        'biocontainers/bcftools:1.20--h8b25389_0' }"
+
+    input:
+    tuple val(meta), path(vcf)
+
+    output:
+    tuple val(meta), path("*.${extension}"), emit: vcf
+    tuple val(meta), path("*.tbi")         , emit: tbi, optional: true
+    tuple val(meta), path("*.csi")         , emit: csi, optional: true
+    path  "versions.yml"                   , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    extension = args.contains("--output-type b") || args.contains("-Ob") ? "bcf.gz" :
+                    args.contains("--output-type u") || args.contains("-Ou") ? "bcf" :
+                    args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
+                    args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
+                    "vcf"
+
+    if ("$vcf" == "${prefix}.${extension}") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
+
+    """
+    bcftools filter \\
+        --output ${prefix}.${extension} \\
+        --threads ${task.cpus} \\
+        $args \\
+        $vcf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    extension = args.contains("--output-type b") || args.contains("-Ob") ? "bcf.gz" :
+                    args.contains("--output-type u") || args.contains("-Ou") ? "bcf" :
+                    args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
+                    args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
+                    "vcf"
+    def index = args.contains("--write-index=tbi") || args.contains("-W=tbi") ? "tbi" :
+                args.contains("--write-index=csi") || args.contains("-W=csi") ? "csi" :
+                args.contains("--write-index") || args.contains("-W") ? "csi" :
+                ""
+    def create_cmd = extension.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_index = extension.endsWith(".gz") && index.matches("csi|tbi") ? "touch ${prefix}.${extension}.${index}" : ""
+
+    if ("$vcf" == "${prefix}.${extension}") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
+
+    """
+    ${create_cmd} ${prefix}.${extension}
+    ${create_index}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bcftools/filter/meta.yml
+++ b/modules/nf-core/bcftools/filter/meta.yml
@@ -1,0 +1,52 @@
+name: bcftools_filter
+description: Filters VCF files
+keywords:
+  - variant calling
+  - filtering
+  - VCF
+tools:
+  - filter:
+      description: |
+        Apply fixed-threshold filters to VCF files.
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: VCF input file
+      pattern: "*.{vcf,bcf,vcf.gz,bcf.gz}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: VCF filtered output file
+      pattern: "*.{vcf,bcf,vcf.gz,bcf.gz}"
+  - csi:
+      type: file
+      description: Default VCF file index
+      pattern: "*.csi"
+  - tbi:
+      type: file
+      description: Alternative VCF file index
+      pattern: "*.tbi"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/bcftools/filter/tests/main.nf.test
+++ b/modules/nf-core/bcftools/filter/tests/main.nf.test
@@ -1,0 +1,253 @@
+nextflow_process {
+
+    name "Test Process BCFTOOLS_FILTER"
+    script "../main.nf"
+    process "BCFTOOLS_FILTER"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bcftools"
+    tag "bcftools/filter"
+
+    test("sarscov2 - vcf") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match("vcf") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz_index") {
+
+        config "./vcf_gz_index.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz_index_csi") {
+
+        config "./vcf_gz_index_csi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz_index_tbi") {
+
+        config "./vcf_gz_index_tbi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf - bcf output") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"bcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match("bcf output") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf - stub") {
+
+        config "./nextflow.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match("vcf - stub") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz_index - stub") {
+
+        config "./vcf_gz_index.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz_index_csi - stub") {
+
+        config "./vcf_gz_index_csi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz_index_tbi - stub") {
+
+        config "./vcf_gz_index_tbi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"vcf_test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bcftools/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/filter/tests/main.nf.test.snap
@@ -1,0 +1,395 @@
+{
+    "sarscov2 - vcf_gz_index_tbi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:59:08.235854993"
+    },
+    "vcf": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T15:20:28.427974818"
+    },
+    "bcf output": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "bcf_test"
+                        },
+                        "bcf_test.bcf.gz:md5,c8a304c8d2892039201154153c8cd536"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "bcf_test"
+                        },
+                        "bcf_test.bcf.gz:md5,c8a304c8d2892039201154153c8cd536"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T15:20:34.049236749"
+    },
+    "sarscov2 - vcf_gz_index": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "vcf_test"
+                    },
+                    "vcf_test_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "vcf_test"
+                    },
+                    "vcf_test_vcf.vcf.gz.csi"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T08:09:49.837854646"
+    },
+    "sarscov2 - vcf_gz_index_csi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "vcf_test"
+                    },
+                    "vcf_test_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "vcf_test"
+                    },
+                    "vcf_test_vcf.vcf.gz.csi"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:57:19.513365022"
+    },
+    "vcf - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T15:29:55.846566153"
+    },
+    "sarscov2 - vcf_gz_index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T15:59:37.636874258"
+    },
+    "sarscov2 - vcf_gz_index_csi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "vcf_test"
+                        },
+                        "vcf_test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:58:46.36278584"
+    },
+    "sarscov2 - vcf_gz_index_tbi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "vcf_test"
+                    },
+                    "vcf_test_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "vcf_test"
+                    },
+                    "vcf_test_vcf.vcf.gz.tbi"
+                ]
+            ],
+            [
+                "versions.yml:md5,9a336d1ee26b527d7a2bdbeead155f64"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:57:34.748836577"
+    }
+}

--- a/modules/nf-core/bcftools/filter/tests/nextflow.config
+++ b/modules/nf-core/bcftools/filter/tests/nextflow.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = {"--no-version${meta.id == 'bcf_test' ? ' --output-type b' : ' --output-type z'}"}
+}

--- a/modules/nf-core/bcftools/filter/tests/tags.yml
+++ b/modules/nf-core/bcftools/filter/tests/tags.yml
@@ -1,0 +1,2 @@
+bcftools/filter:
+  - "modules/nf-core/bcftools/filter/**"

--- a/modules/nf-core/bcftools/filter/tests/vcf_gz_index.config
+++ b/modules/nf-core/bcftools/filter/tests/vcf_gz_index.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index --no-version"
+}

--- a/modules/nf-core/bcftools/filter/tests/vcf_gz_index_csi.config
+++ b/modules/nf-core/bcftools/filter/tests/vcf_gz_index_csi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=csi --no-version"
+}

--- a/modules/nf-core/bcftools/filter/tests/vcf_gz_index_tbi.config
+++ b/modules/nf-core/bcftools/filter/tests/vcf_gz_index_tbi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=tbi --no-version"
+}

--- a/modules/nf-core/bcftools/norm/environment.yml
+++ b/modules/nf-core/bcftools/norm/environment.yml
@@ -1,0 +1,7 @@
+name: bcftools_norm
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bcftools=1.20

--- a/modules/nf-core/bcftools/norm/main.nf
+++ b/modules/nf-core/bcftools/norm/main.nf
@@ -1,0 +1,70 @@
+process BCFTOOLS_NORM {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bcftools:1.20--h8b25389_0':
+        'biocontainers/bcftools:1.20--h8b25389_0' }"
+
+    input:
+    tuple val(meta), path(vcf), path(tbi)
+    tuple val(meta2), path(fasta)
+
+    output:
+    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bcf.gz}"), emit: vcf
+    tuple val(meta), path("*.tbi")                    , emit: tbi, optional: true
+    tuple val(meta), path("*.csi")                    , emit: csi, optional: true
+    path "versions.yml"                               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: '--output-type z'
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args.contains("--output-type b") || args.contains("-Ob") ? "bcf.gz" :
+                    args.contains("--output-type u") || args.contains("-Ou") ? "bcf" :
+                    args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
+                    args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
+                    "vcf.gz"
+
+    """
+    bcftools norm \\
+        --fasta-ref ${fasta} \\
+        --output ${prefix}.${extension}\\
+        $args \\
+        --threads $task.cpus \\
+        ${vcf}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: '--output-type z'
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args.contains("--output-type b") || args.contains("-Ob") ? "bcf.gz" :
+                    args.contains("--output-type u") || args.contains("-Ou") ? "bcf" :
+                    args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
+                    args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
+                    "vcf.gz"
+    def index = args.contains("--write-index=tbi") || args.contains("-W=tbi") ? "tbi" :
+                args.contains("--write-index=csi") || args.contains("-W=csi") ? "csi" :
+                args.contains("--write-index") || args.contains("-W") ? "csi" :
+                ""
+    def create_cmd = extension.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_index = extension.endsWith(".gz") && index.matches("csi|tbi") ? "touch ${prefix}.${extension}.${index}" : ""
+
+    """
+    ${create_cmd} ${prefix}.${extension}
+    ${create_index}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bcftools/norm/meta.yml
+++ b/modules/nf-core/bcftools/norm/meta.yml
@@ -1,0 +1,69 @@
+name: bcftools_norm
+description: Normalize VCF file
+keywords:
+  - normalize
+  - norm
+  - variant calling
+  - VCF
+tools:
+  - norm:
+      description: |
+        Normalize VCF files.
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: |
+        The vcf file to be normalized
+        e.g. 'file1.vcf'
+      pattern: "*.{vcf,vcf.gz}"
+  - tbi:
+      type: file
+      description: |
+        An optional index of the VCF file (for when the VCF is compressed)
+      pattern: "*.vcf.gz.tbi"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'genome' ]
+  - fasta:
+      type: file
+      description: FASTA reference file
+      pattern: "*.{fasta,fa}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: One of uncompressed VCF (.vcf), compressed VCF (.vcf.gz), compressed BCF (.bcf.gz) or uncompressed BCF (.bcf) normalized output file
+      pattern: "*.{vcf,vcf.gz,bcf,bcf.gz}"
+  - csi:
+      type: file
+      description: Default VCF file index
+      pattern: "*.csi"
+  - tbi:
+      type: file
+      description: Alternative VCF file index
+      pattern: "*.tbi"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@abhi18av"
+  - "@ramprasadn"
+maintainers:
+  - "@abhi18av"
+  - "@ramprasadn"

--- a/modules/nf-core/bcftools/norm/tests/main.nf.test
+++ b/modules/nf-core/bcftools/norm/tests/main.nf.test
@@ -1,0 +1,563 @@
+nextflow_process {
+
+    name "Test Process BCFTOOLS_NORM"
+    script "../main.nf"
+    process "BCFTOOLS_NORM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bcftools"
+    tag "bcftools/norm"
+
+    test("sarscov2 - [ vcf, [] ], fasta") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - vcf_gz_index") {
+
+        config "./vcf_gz_index.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } }
+                    ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_csi") {
+
+        config "./vcf_gz_index_csi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } }
+                    ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_tbi") {
+
+        config "./vcf_gz_index_tbi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } }
+                    ).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - vcf output") {
+
+        config "./nextflow.vcf.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - vcf_gz output") {
+
+        config "./nextflow.vcf.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - bcf output") {
+
+        config "./nextflow.bcf.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - bcf_gz output") {
+
+        config "./nextflow.bcf_gz.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - stub") {
+
+        config "./nextflow.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta -stub") {
+
+        config "./nextflow.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - vcf output -stub") {
+
+        config "./nextflow.vcf.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - vcf_gz output - stub") {
+
+        config "./nextflow.vcf.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - bcf output - stub") {
+
+        config "./nextflow.bcf.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, tbi ], fasta - bcf_gz output - stub") {
+
+        config "./nextflow.bcf_gz.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - vcf_gz_index - stub") {
+
+        config "./vcf_gz_index.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_csi - stub") {
+
+        config "./vcf_gz_index_csi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_tbi - stub") {
+
+        config "./vcf_gz_index_tbi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    []
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+
+    }
+
+
+}

--- a/modules/nf-core/bcftools/norm/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/norm/tests/main.nf.test.snap
@@ -1,0 +1,758 @@
+{
+    "sarscov2 - [ vcf, tbi ], fasta - vcf_gz output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:38:42.639095032"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:38:05.448449893"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - vcf output": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:37:12.741719961"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - vcf_gz_index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:39:22.875147941"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - vcf_gz output": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_norm.vcf:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T08:15:23.38765384"
+    },
+    "sarscov2 - [ vcf, [] ], fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:36:21.519977754"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - vcf output -stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:38:27.8230994"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - bcf_gz output": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf:md5,f35545c26a788b5eb697d9c0490339d9"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf:md5,f35545c26a788b5eb697d9c0490339d9"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:37:53.942403192"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_csi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:56:05.3799488"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_tbi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_vcf.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                ]
+            ],
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:53:28.356741947"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:36:58.39445154"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta -stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:38:16.259516142"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - bcf_gz output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:39:10.503208929"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - vcf_gz_index": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_vcf.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_vcf.vcf.gz.csi"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T07:52:58.381931979"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - bcf output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:38:59.121377258"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_tbi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:56:16.404380471"
+    },
+    "sarscov2 - [ vcf, [] ], fasta - vcf_gz_index_csi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_vcf.vcf.gz:md5,63e5adbaf3dd94550e9e3d7935dd28db"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_vcf.vcf.gz.csi"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-05T13:53:09.808834237"
+    },
+    "sarscov2 - [ vcf, tbi ], fasta - bcf output": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf.gz:md5,638c3c25bdd495c90ecbccb69ee77f07"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_norm.bcf.gz:md5,638c3c25bdd495c90ecbccb69ee77f07"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ff760495922469e56d0fc3372773000d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-04T14:37:42.141945244"
+    }
+}

--- a/modules/nf-core/bcftools/norm/tests/nextflow.bcf.config
+++ b/modules/nf-core/bcftools/norm/tests/nextflow.bcf.config
@@ -1,0 +1,4 @@
+process {
+    ext.args = '-m -any --output-type b --no-version'
+    ext.prefix = "test_norm"
+}

--- a/modules/nf-core/bcftools/norm/tests/nextflow.bcf_gz.config
+++ b/modules/nf-core/bcftools/norm/tests/nextflow.bcf_gz.config
@@ -1,0 +1,4 @@
+process {
+    ext.args = '-m -any --output-type u --no-version'
+    ext.prefix = "test_norm"
+}

--- a/modules/nf-core/bcftools/norm/tests/nextflow.config
+++ b/modules/nf-core/bcftools/norm/tests/nextflow.config
@@ -1,0 +1,4 @@
+process {
+    ext.args = '-m -any --no-version'
+    ext.prefix = "test_norm"
+}

--- a/modules/nf-core/bcftools/norm/tests/nextflow.vcf.config
+++ b/modules/nf-core/bcftools/norm/tests/nextflow.vcf.config
@@ -1,0 +1,4 @@
+process {
+    ext.args = '-m -any --output-type v --no-version'
+    ext.prefix = "test_norm"
+}

--- a/modules/nf-core/bcftools/norm/tests/nextflow.vcf_gz.config
+++ b/modules/nf-core/bcftools/norm/tests/nextflow.vcf_gz.config
@@ -1,0 +1,4 @@
+process {
+    ext.args = '-m -any --output-type z ---no-version'
+    ext.prefix = "test_norm"
+}

--- a/modules/nf-core/bcftools/norm/tests/tags.yml
+++ b/modules/nf-core/bcftools/norm/tests/tags.yml
@@ -1,0 +1,2 @@
+bcftools/norm:
+  - "modules/nf-core/bcftools/norm/**"

--- a/modules/nf-core/bcftools/norm/tests/vcf_gz_index.config
+++ b/modules/nf-core/bcftools/norm/tests/vcf_gz_index.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index --no-version"
+}

--- a/modules/nf-core/bcftools/norm/tests/vcf_gz_index_csi.config
+++ b/modules/nf-core/bcftools/norm/tests/vcf_gz_index_csi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=csi --no-version"
+}

--- a/modules/nf-core/bcftools/norm/tests/vcf_gz_index_tbi.config
+++ b/modules/nf-core/bcftools/norm/tests/vcf_gz_index_tbi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=tbi --no-version"
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -219,7 +219,7 @@ process {
 		container = 'staphb/htslib:1.19'
 	}
 
-	withName: 'BCFTOOLS_FILTER|BCFTOOLS_NORM|BCFTOOLS_INDEX' {
+	withName: 'BCFTOOLS_FILTER|BCFTOOLS_NORM' {
 		errorStrategy = 'retry'
 		maxRetries = 1
 		cpus	=	{ check_max( 2 		* task.attempt, 'cpus' 		) 	}

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,6 +64,8 @@ params {
     validationShowHiddenParams       = false
     validate_params                  = true
 
+
+    modules_testdata_base_path = 's3://ngi-igenomes/testdata/nf-core/modules/'
 }
 
 // Load base.config by default for all pipelines
@@ -76,12 +78,6 @@ try {
     System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
 }
 
-// Load ferlab/postprocessing custom profiles from different institutions.
-try {
-    includeConfig "${params.custom_config_base}/pipeline/postprocessing.config"
-} catch (Exception e) {
-    System.err.println("WARNING: Could not load nf-core/config/postprocessing profiles: ${params.custom_config_base}/pipeline/postprocessing.config")
-}
 profiles {
     debug {
         dumpHashes              = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -209,9 +209,6 @@ env {
 
 process {
   disk = 40.GB
-	withName: 'excludeMNPs|splitMultiAllelics' {
-		container = 'staphb/bcftools:1.19'
-	}
 	withName: 'importGVCF|genotypeGVCF_multi|genotypeGVCF_solo|genotypeGVCF|variantRecalibratorSNP|variantRecalibratorIndel|applyVQSRIndel|applyVQSRSNP|hardFiltering|gatherVCF' {
 		container = 'broadinstitute/gatk:4.5.0.0'
 	}
@@ -222,7 +219,7 @@ process {
 		container = 'staphb/htslib:1.19'
 	}
 
-	withName: 'excludeMNPs' {
+	withName: 'BCFTOOLS_FILTER|BCFTOOLS_NORM|BCFTOOLS_INDEX' {
 		errorStrategy = 'retry'
 		maxRetries = 1
 		cpus	=	{ check_max( 2 		* task.attempt, 'cpus' 		) 	}

--- a/nextflow.config
+++ b/nextflow.config
@@ -65,7 +65,6 @@ params {
     validate_params                  = true
 
 
-    modules_testdata_base_path = 's3://ngi-igenomes/testdata/nf-core/modules/'
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -274,5 +274,11 @@
     {
       "$ref": "#/definitions/generic_options"
     }
-  ]
+  ],
+  "properties": {
+    "modules_testdata_base_path": {
+      "type": "string",
+      "default": "s3://ngi-igenomes/testdata/nf-core/modules/"
+    }
+  }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -81,7 +81,13 @@
           "format": "file-path"
         }
       },
-      "required": ["broad", "intervalsFile", "referenceGenome", "referenceGenomeFasta", "vepCache"]
+      "required": [
+        "broad",
+        "intervalsFile",
+        "referenceGenome",
+        "referenceGenomeFasta",
+        "vepCache"
+      ]
     },
     "institutional_config_options": {
       "title": "Institutional config options",
@@ -275,10 +281,5 @@
       "$ref": "#/definitions/generic_options"
     }
   ],
-  "properties": {
-    "modules_testdata_base_path": {
-      "type": "string",
-      "default": "s3://ngi-igenomes/testdata/nf-core/modules/"
-    }
-  }
+  "properties": {}
 }

--- a/subworkflows/local/exclude_mnps/main.nf
+++ b/subworkflows/local/exclude_mnps/main.nf
@@ -1,0 +1,26 @@
+include { BCFTOOLS_FILTER} from '../../../modules/nf-core/bcftools/filter/main'
+include { BCFTOOLS_NORM } from '../../../modules/nf-core/bcftools/norm/main'    
+/**
+Separates MNPs into several SNP that will be analyzed separately
+
+The input and output formats are the same:
+    Input: ([meta]  [some.file.vcf.gz, some.file.vcf.gz.tbi])
+
+*/
+workflow EXCLUDE_MNPS {
+    take:
+        input // channel: (val(metas),  [.gvcf.gz])
+    main:
+
+        BCFTOOLS_FILTER(input)
+        referencepath = file("${params.referenceGenome}/${params.referenceGenomeFasta}")
+        ch_reference = input.map{meta,file -> [meta,referencepath]}
+
+        ch_bcftoolsfilter_for_bcftoolsnorm = BCFTOOLS_FILTER.out.vcf.join(BCFTOOLS_FILTER.out.tbi)
+
+        BCFTOOLS_NORM(ch_bcftoolsfilter_for_bcftoolsnorm,ch_reference)
+        ch_output_excludemnps = BCFTOOLS_NORM.out.vcf.join(BCFTOOLS_NORM.out.tbi)
+            .map{meta, vcf, tbi ->[meta,[vcf,tbi]]}
+    emit:
+        ch_output_excludemnps // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
+}

--- a/subworkflows/local/exclude_mnps/main.nf
+++ b/subworkflows/local/exclude_mnps/main.nf
@@ -12,13 +12,12 @@ workflow EXCLUDE_MNPS {
         input // channel: (val(metas),  [.gvcf.gz])
     main:
     versions = Channel.empty()
-    referencepath = file("${params.referenceGenome}/${params.referenceGenomeFasta}")
-    ch_bcftoolsfilter_input = input.map{meta,file -> [meta + [id: meta.familyId + "." + meta.sample],file]} //meta.id is referenced in modules
-    ch_reference = input.map{meta,file -> [meta,referencepath]}
-    BCFTOOLS_FILTER(ch_bcftoolsfilter_input)
+    def reference_path = file("${params.referenceGenome}/${params.referenceGenomeFasta}")
+    BCFTOOLS_FILTER(input)
 
-    ch_bcftoolsfilter_for_bcftoolsnorm = BCFTOOLS_FILTER.out.vcf.join(BCFTOOLS_FILTER.out.tbi)
+    def ch_bcftoolsfilter_for_bcftoolsnorm = BCFTOOLS_FILTER.out.vcf.join(BCFTOOLS_FILTER.out.tbi)
 
+    ch_reference = input.map{meta,file -> [meta,reference_path]}
     BCFTOOLS_NORM(ch_bcftoolsfilter_for_bcftoolsnorm,ch_reference)
     ch_output_excludemnps = BCFTOOLS_NORM.out.vcf.join(BCFTOOLS_NORM.out.tbi)
         .map{meta, vcf, tbi ->[meta,[vcf,tbi]]}

--- a/subworkflows/local/exclude_mnps/main.nf
+++ b/subworkflows/local/exclude_mnps/main.nf
@@ -11,16 +11,21 @@ workflow EXCLUDE_MNPS {
     take:
         input // channel: (val(metas),  [.gvcf.gz])
     main:
+    versions = Channel.empty()
+    referencepath = file("${params.referenceGenome}/${params.referenceGenomeFasta}")
+    ch_bcftoolsfilter_input = input.map{meta,file -> [meta + [id: meta.familyId + "." + meta.sample],file]} //meta.id is referenced in modules
+    ch_reference = input.map{meta,file -> [meta,referencepath]}
+    BCFTOOLS_FILTER(ch_bcftoolsfilter_input)
 
-        BCFTOOLS_FILTER(input)
-        referencepath = file("${params.referenceGenome}/${params.referenceGenomeFasta}")
-        ch_reference = input.map{meta,file -> [meta,referencepath]}
+    ch_bcftoolsfilter_for_bcftoolsnorm = BCFTOOLS_FILTER.out.vcf.join(BCFTOOLS_FILTER.out.tbi)
 
-        ch_bcftoolsfilter_for_bcftoolsnorm = BCFTOOLS_FILTER.out.vcf.join(BCFTOOLS_FILTER.out.tbi)
+    BCFTOOLS_NORM(ch_bcftoolsfilter_for_bcftoolsnorm,ch_reference)
+    ch_output_excludemnps = BCFTOOLS_NORM.out.vcf.join(BCFTOOLS_NORM.out.tbi)
+        .map{meta, vcf, tbi ->[meta,[vcf,tbi]]}
 
-        BCFTOOLS_NORM(ch_bcftoolsfilter_for_bcftoolsnorm,ch_reference)
-        ch_output_excludemnps = BCFTOOLS_NORM.out.vcf.join(BCFTOOLS_NORM.out.tbi)
-            .map{meta, vcf, tbi ->[meta,[vcf,tbi]]}
+    versions = versions.mix(BCFTOOLS_FILTER.out.versions)
+    versions = versions.mix(BCFTOOLS_NORM.out.versions)
     emit:
         ch_output_excludemnps // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
+        versions
 }

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -94,8 +94,9 @@ workflow PIPELINE_INITIALISATION {
         .combine(ch_sample_simple,by:0)
         .map {
             id,size,metasfile -> //include sample count in meta
+                def meta = metasfile[0]
                 [
-                    metasfile[0] + [sampleSize: size], //meta
+                    meta + [sampleSize: size] + [id: meta.familyId + "." + meta.sample], //meta.id is referenced in modules
                     metasfile[1]                       //file
                 ]
         }.set {ch_samplesheet}

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -19,37 +19,6 @@ include { tabix                  } from '../modules/local/vep'
     RUN MAIN WORKFLOW
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-
-process excludeMNPs {
-    label 'medium'
-    
-    input:
-    tuple val(metas), path(gvcfFile)
-
-    output:
-    tuple val(metas), path("*filtered.vcf.gz*")
-
-    script:
-    def familyId = meta.familyId
-    def sample = meta.sample
-    def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
-    """
-    set -e
-    echo $familyId > file
-    bcftools filter -e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"' ${exactGvcfFile} | bcftools norm -d any -O z -o ${familyId}.${sample}.filtered.vcf.gz
-    bcftools index -t ${familyId}.${sample}.filtered.vcf.gz
-    """
-    stub:
-    def familyId = meta.familyId
-    def sample = meta.sample
-    def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
-    """
-    touch ${familyId}.${sample}.filtered.vcf.gz
-    touch ${familyId}.${sample}.filtered.vcf.gz.tbi
-    """
-
-}
-
 /**
 Combine per-sample gVCF files into a multi-sample gVCF file 
 */

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -173,7 +173,7 @@ workflow POSTPROCESSING {
     .collectFile(storeDir: "${params.outdir}/pipeline_info/configs",cache: false)
 
     writemeta()
-    filtered = EXCLUDE_MNPS(ch_samplesheet)
+    filtered = EXCLUDE_MNPS(ch_samplesheet).ch_output_excludemnps
                     .map{metas, files -> tuple( groupKey(metas.familyId, metas.sampleSize),metas,files)}
                     .groupTuple()
                     .map{ familyId, metas, files -> //now that samples are grouped together, we no longer follow sample in meta

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -174,11 +174,11 @@ workflow POSTPROCESSING {
 
     writemeta()
     filtered = EXCLUDE_MNPS(ch_samplesheet).ch_output_excludemnps
-                    .map{metas, files -> tuple( groupKey(metas.familyId, metas.sampleSize),metas,files)}
+                    .map{meta, files -> tuple( groupKey(meta.familyId, meta.sampleSize),meta,files)}
                     .groupTuple()
-                    .map{ familyId, metas, files -> //now that samples are grouped together, we no longer follow sample in meta
+                    .map{ familyId, meta, files -> //now that samples are grouped together, we no longer follow sample in meta
                         [
-                            metas[0].findAll{it.key != "sample"}, //meta
+                            meta[0].findAll{it.key != "sample"}, //meta
                             files.flatten()]}                     //files
     //Using 2 as threshold because we have 2 files per patient (gcvf.gz, gvcf.gz.tbi)
     filtered_one = filtered.filter{it[0].sampleSize == 1}

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -24,10 +24,10 @@ process excludeMNPs {
     label 'medium'
     
     input:
-    tuple val(meta), path(gvcfFile)
+    tuple val(metas), path(gvcfFile)
 
     output:
-    tuple val(meta), path("*filtered.vcf.gz*")
+    tuple val(metas), path("*filtered.vcf.gz*")
 
     script:
     def familyId = meta.familyId
@@ -81,13 +81,13 @@ process importGVCF {
 
 
     """
-    echo $familyId > file
+    echo $familyID > file
     gatk -version
     gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData $argsjava" \\
         CombineGVCFs \\
         -R $referenceGenome/${params.referenceGenomeFasta} \\
         $exactGvcfFiles \\
-        -O ${familyId}.combined.gvcf.gz \\
+        -O ${familyID}.combined.gvcf.gz \\
         -L $broadResource/${params.intervalsFile} \\
         $args
     """ 
@@ -98,7 +98,7 @@ process importGVCF {
     def exactGvcfFiles = gvcfFiles.findAll { it.name.endsWith("vcf.gz") }.collect { "-V $it" }.join(' ')
 
     """
-    touch ${familyId}.combined.gvcf.gz
+    touch ${familyID}.combined.gvcf.gz
     """       
 
 }    
@@ -130,13 +130,13 @@ process genotypeGVCF {
         avail_mem = (task.memory.mega*0.8).intValue()
     }
     """
-    echo $familyId > file
+    echo $familyID > file
     gatk -version
     gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData $argsjava" \\
         GenotypeGVCFs \\
         -R $referenceGenome/${params.referenceGenomeFasta} \\
         -V $exactGvcfFile \\
-        -O ${familyId}.genotyped.vcf.gz \\
+        -O ${familyID}.genotyped.vcf.gz \\
         $args
     """
 
@@ -145,7 +145,7 @@ process genotypeGVCF {
     def familyId = meta.familyId
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
     """
-    touch ${familyId}.genotyped.vcf.gz
+    touch ${familyID}.genotyped.vcf.gz
     """
 }
 


### PR DESCRIPTION
Converts the exclude_MNPs process into a subworkflow containing 2 nf-core modules: [BCFTOOLS_FILTER](https://github.com/nf-core/modules/tree/master/modules/nf-core/bcftools/filter) and [BCFTOOLS_NORM](https://github.com/nf-core/modules/tree/master/modules/nf-core/bcftools/norm). 
The indexing module was not found to be necessary, since both the filter and the norm can write tbi index files as of bcftools 1.20. As a result, the bcftools container was updated to 1.20, to reflect the installed nf-core modules as well.
 
External options are passed as ext.args via modules.config, however the nf-core BCFTOOLS_NORM module includes by default the --fasta-ref option, which changes the logic of the function (as described [here](https://samtools.github.io/bcftools/bcftools.html#norm)) and was not included in the original exclude_MNP process. The inclusion of the --fasta-ref involves passing the reference file to the module, and triggers normalization of the vcf. This was probably not the intent of the original function, however Damien did not find a change between doing the normalization and canceling it with the -N option. For now, -N is not used and the vcf file will be theoretically normalized until we decide otherwise. 
See our [notion page](https://www.notion.so/ferlab/Notes-for-nf-core-modules-subworkflows-1cb401615ea149278b87c12e9284745d) for the notes regarding these changes.

This branch lints and was tested locally and on Juno.