### PR TITLE
fix: CLIN-3090 run test in stub mode in github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: nf-core CI
 on:
   push:
     branches:
-      - dev
+      - main
+    tags:
+      - v*
   pull_request:
-  release:
-    types: [published]
 
 env:
   NXF_ANSI_LOG: false
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "23.04.0"
+          - "23.10.1"
           - "latest-everything"
     steps:
       - name: Check out pipeline code
@@ -39,8 +39,9 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 
       - name: Run pipeline with test data
-        # TODO nf-core: You can customise CI pipeline run tests as required
-        # For example: adding multiple test runs with different parameters
-        # Remember that you can parallelise this by using strategy.matrix
+       # Add as many test runs as needed here. Remember that you can parallelise this by
+       # using strategy.matrix.
+
+        # Using the stub mode until our test data setup is ready
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
+          nextflow run ${GITHUB_WORKSPACE} -stub -profile test,docker

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,14 +1,13 @@
 name: nf-core linting
-# This workflow is triggered on pushes and PRs to the repository.
-# It runs the `nf-core lint` and markdown lint tests to ensure
-# that the code meets the nf-core guidelines.
+# This workflow runs the `nf-core lint` and markdown lint tests to ensure
+# code quality and adherence to relevant nf-core guidelines.
 on:
   push:
     branches:
-      - dev
+      - main
+    tags:
+      - v*
   pull_request:
-  release:
-    types: [published]
 
 jobs:
   pre-commit:

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,4 +1,5 @@
 lint:
+  actions_ci: False
   files_exist:
   - CODE_OF_CONDUCT.md
   - assets/nf-core-postprocessing_logo_light.png
@@ -27,6 +28,7 @@ lint:
   - .github/CONTRIBUTING.md
   - .github/PULL_REQUEST_TEMPLATE.md
   - .github/workflows/linting_comment.yml
+  - .github/workflows/linting.yml
   - LICENSE
   multiqc_config:
   - report_comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-co.re/) template.
 
 ### `Added`
-[#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Added tests and samplefile channel functions
-[#3](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/3) Added a test file for the test profile
-[#7](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/7) Added most functions and modules from previous pipeline to make it functional
-[#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9) New format "V3" is now supported. Includes metadata propagation. 
+- [#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Added tests and samplefile channel functions
+- [#3](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/3) Added a test file for the test profile
+- [#7](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/7) Added most functions and modules from previous pipeline to make it functional
+- [#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9) New format "V3" is now supported. Includes metadata propagation. 
 
 ### `Fixed`
-[#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Fixed template schemas
+- [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Fixed template schemas
+- [#13](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/13) Run test in stub mode in GitLab workflow with necessary adjustments
+- [#13](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/13) Add missing docker image for process writemeta
+- [#13](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/13) Fix bug with extra java arguments in process genotypeGVCF
+
 
 ### `Dependencies`
 
 ### `Deprecated`
-Format "V1" and "V2" are now deprecated as of [#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9)
+- Format "V1" and "V2" are now deprecated as of [#9](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/9)
+
 ### `Removed`
-[#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Removed input_schema
-[#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Removed V1 format input. V2 is the only accepted format.
-[#5](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/5) Removed many files related to workflows and email notifications
-[#8](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/8) Removed remaining unnecessary workflows including the linting fix, the branch protection workflow and the "download pipeline" workflow
+- [#1](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/1) Removed input_schema
+- [#2](https://github.com/FelixAntoineLeSieur/Post-processing-Pipeline/pull/2) Removed V1 format input. V2 is the only accepted format.
+- [#5](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/5) Removed many files related to workflows and email notifications
+- [#8](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/8) Removed remaining unnecessary workflows including the linting fix, the branch protection workflow and the "download pipeline" workflow
+- [#13](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/13) Removed linter tests on gitHub workflows to customize them to our needs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.04.0-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.10.1-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/assets/TestSampleSheet.csv
+++ b/assets/TestSampleSheet.csv
@@ -1,0 +1,4 @@
+familyId,sample,sequencingType,gvcf
+Family1,Test1,WES,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz
+Family1,Test2,WES,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz
+Family2,Test3,WGS,https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/assets/TestSampleSheet.tsv
+++ b/assets/TestSampleSheet.tsv
@@ -1,2 +1,0 @@
-familyId,sample,sequencingType,file
-Family1,Test1,WES,https://raw.githubusercontent.com/nf-core/test-datasets/sarek3/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz   https://raw.githubusercontent.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz

--- a/conf/test.config
+++ b/conf/test.config
@@ -19,11 +19,15 @@ params {
     max_memory = '6.GB'
     max_time   = '6.h'
 
-    // Input data
-    // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
-    // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    input  = "$projectDir/assets/TestSampleSheet.tsv"
+    // Input and output
+    input  = "$projectDir/assets/TestSampleSheet.csv"
+    outdir = "$projectDir/results"
 
-    // Genome references
-    genome = 'R64-1-1'
+    // Stub values are used for these parameters. They will be replaced with actual values when our test data setup is 
+    // ready.
+    intervalsFile = "interval_long_local.list"
+    broad = "broad"
+    referenceGenome = "reference/Genome/directory"
+    referenceGenomeFasta = "genome.fasta"
+    vepCache = "vepCache"
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -286,6 +286,9 @@ process {
 		disk	=	{ check_max( 80.GB	* task.attempt, 'disk'		)	}
 		time	=	{ check_max( 10.h 	* task.attempt, 'time'		)	}
 	}
+    withName: 'writemeta' {
+        container = 'ubuntu:24.10'	
+    }
 }
 
 // Function to ensure that resource requirements don't go beyond
@@ -362,7 +365,7 @@ manifest {
     homePage        = 'https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline'
     description     = """Variant analysis for genome and exome GVCFs"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=23.04.0'
+    nextflowVersion = '!>=23.10.1'
     version         = '1.0dev'
     doi             = ''
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -81,7 +81,7 @@
           "format": "file-path"
         }
       },
-      "required": ["intervalsFile"]
+      "required": ["broad", "intervalsFile", "referenceGenome", "referenceGenomeFasta", "vepCache"]
     },
     "institutional_config_options": {
       "title": "Institutional config options",

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -120,7 +120,7 @@ process genotypeGVCF {
     script:
     def familyId = meta.familyId
     def args = task.ext.args ?: ''
-    def argsjava = task.ext.args ?: ''
+    def argsjava = task.ext.argsjava ?: ''
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
 
     def avail_mem = 3072


### PR DESCRIPTION
## Allow to run the post processing pipeline in stub mode in the github workflow ci.yml.

We adjusted a few things to make this work:
- fix bugs in test sample sheet and make it cover both WGS an WES sequencing types
- complete the test profile and add missing required parameters in schema
- adjusted the github workflow command to add the -stub option

We also take the oppotunity to do a bit of cleanup on the github workflow files:
 - align trigger rules with ferlab git flow (sadly had to disable 2 linter tests to allow this)
 - use the same nextflow version as in production (23.10.1)
 
 Other changes:
- We realized  while testing on juno that the docker image for process writemeta was missing, so we add it in nextflow.config
- We also realized that the changelog was not displayed correctly in the UI.  We fixed that.
- Fix bug with extra java arguments in process CombineGVCF

## Test description ##

We make sure that github workflow is executed correctly on this PR

**Local tests:**

- We run `nf-core lint` and check that no test is failing and that there are no new warnings caused by the changes here. Actually, we got rid of 3 warnings (TODO keywords found in doc).
- Check that the following commands work locally:
```
nextflow run main.nf -stub -profile test,docker
nextflow run main.nf -stub -profile test
```

**Tests on juno:**

Was able to run a job successfully:
```
 nextflow -c /root/nextflow/config/fusion.config  -c tweaks.config run Ferlab-Ste-Justine/Post-processing-Pipeline -r fix/CLIN-3090-run-test-in-stub-mode-in-github-workflow -params-file params.json -work-dir s3://cqdg-prod-file-scratch/nextflow/scratch/lysiane
 ```
 I started from remi antoine's test dataset.  I found 2 bugs while doing that:
 - gvcf file extension .g.vcf.gz not supported
 - For some processes, it is assumed that both extra arguments and extra java options are passed via ext.args, which does not work.

I think that they should be addressed in dedicated PRs. For the first bug, I simply copied my input file into a new file with extension .gvcf.  For the second bug, I commited a fix specifically for the process causing problem for my test, but the problem is present in other processes as well.
 
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
