### PR TITLE
feat: add nextflow docker image

### DIFF
--- a/.github/workflows/publish_with_latest.yml
+++ b/.github/workflows/publish_with_latest.yml
@@ -1,0 +1,22 @@
+name: Publish Image Using latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push:
+    name: Publish Image using latest tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/nextflow
+          location: containers/nextflow
+          dockerfile: containers/nextflow/Dockerfile
+          tag_format: "latest"

--- a/.github/workflows/publish_with_semver_tag.yml
+++ b/.github/workflows/publish_with_semver_tag.yml
@@ -1,0 +1,22 @@
+name: Publish Image Using Semver Tag
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  push:
+    name: Publish Image using tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/nextflow
+          location: containers/nextflow
+          dockerfile: containers/nextflow/Dockerfile
+          tag_format: "{semver}"

--- a/.github/workflows/publish_with_sha.yml
+++ b/.github/workflows/publish_with_sha.yml
@@ -1,0 +1,22 @@
+name: Publish Image Using Sha and Timestamp
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push:
+    name: Publish Image using commit sha and timestamp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/nextflow
+          location: containers/nextflow
+          dockerfile: containers/nextflow/Dockerfile
+          tag_format: "{sha}-{timestamp}"

--- a/containers/nextflow/Dockerfile
+++ b/containers/nextflow/Dockerfile
@@ -1,0 +1,19 @@
+# The container created from this image is used as a jump point within the
+# kubernetes cluster to submit various ad-hoc jobs.
+
+FROM nextflow/nextflow:23.10.1
+
+# Adding a few command line utilities
+RUN yum update -y && yum install -y --setopt=skip_missing_names_on_install=False \
+nano-2.9.8-2.amzn2.0.1.x86_64 \
+tar-2:1.26-35.amzn2.0.3.x86_64 \
+less-458-9.amzn2.0.4.x86_64 \
+wget-1.14-18.amzn2.1.x86_64 \
+unzip-6.0-57.amzn2.0.1.x86_64 \
+zip-3.0-11.amzn2.0.2.x86_64 \
+rclone-1.55.1-1.amzn2.0.1.x86_64
+
+# Installing the aws cli. Using version >= 2.13.0 so that environment variable AWS_ENDPOINT_URL is supported
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.0.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install

--- a/containers/nextflow/README.md
+++ b/containers/nextflow/README.md
@@ -1,0 +1,20 @@
+This docker image is designed to create long-running Nextflow pods. It includes nextflow and several command-line
+utilities such as the AWS CLI and Rclone. Additionally, it provides more basic linux commands like tar, which are 
+not included in the base nextflow image.
+
+## Local Testing Commands
+
+To build it locally, you can use the following command from the project root directory:
+
+```
+docker build containers/nextflow -t ferlabcrsj/nextflow:dev
+```
+
+
+To open a shell on a docker container created from this image, run the following command:
+
+```
+docker run -it --rm ferlabcrsj/nextflow:dev /bin/bash
+```
+
+Since the `--rm` option is specified, the container will be automatically deleted once you exit the shell.


### PR DESCRIPTION
I tested that there is no new warnings from nf-core linter caused by the changes.
I checked that I could build the docker image locally and start a container with it.

I did not cover details of the tools installed on the image as the dockerfile is an exact copy of the dockerfile on our previous repo (cqdg-denovo-nextflow) and was already thorougly tested in the past.

I did not covered github workflows logic as this is very complicated to test locally.  If they malfunction, it should not break the pipeline code itself.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
