### PR TITLE
feat: bump version to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0dev - [date]
+
+## v2.0.0dev - [date]
+
+## v1.0dev
 
 Initial release of ferlab/postprocessing, created with the [nf-core](https://nf-co.re/) template.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -358,7 +358,7 @@ manifest {
     description     = """Variant analysis for genome and exome GVCFs"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.10.1'
-    version         = '1.0dev'
+    version         = '2.0.0dev'
     doi             = ''
 }
 


### PR DESCRIPTION
I bumped the version to v2.0.0dev.

I used a version number higher than latest cqdg-denovo-nextflow tag (v1.1.2), so that official releases are in continuation.  
I used the following nf-core command to bump the version:
```
nf-core bump-version v2.0.0dev
```

The `v` prefix was automatically stripped. If I don't add the dev suffix at the end, the linter complains.

I checked that the previous version tag does not appear in other files with a find command in my IDE.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
