### PR TITLE
feat: CLIN-2947 add version file in exomiser docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## v2.0.0dev - [date]
-### Known issues:
 
-[#20](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/20) The nf-core module genotypeGVCFs has a potential performance flaw. The output glob specifies for vcf and tbi *.vcf and *.vcf.tbi respectively. This regex will also include the inputs, which can cause unnecessary file transfers. This has already proven to cause issues on fusion. One fix could be to transfer the whole module to local to perform the small change necessary to fix this (change the globs to *${prefix}.vcf)
+### `Added`
+- [#26](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/26) Add version file in exomiser docker image
+
+### `Known issues`
+- [#20](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/20) The nf-core module genotypeGVCFs has a potential performance flaw. The output glob specifies for vcf and tbi *.vcf and *.vcf.tbi respectively. This regex will also include the inputs, which can cause unnecessary file transfers. This has already proven to cause issues on fusion. One fix could be to transfer the whole module to local to perform the small change necessary to fix this (change the globs to *${prefix}.vcf)
 
 
 ## v1.0dev

--- a/containers/exomiser/Dockerfile
+++ b/containers/exomiser/Dockerfile
@@ -5,5 +5,10 @@ RUN apt-get update && \
     apt-get install -y procps=2:3.3.17-6ubuntu2.1 && \
     rm -rf /var/lib/apt/lists/*
 
+
+# Create a file containing the exomiser version, as there is no way to retrieve it from the exomiser-cli.
+# Ensure to update this file whenever you update the base exomiser image.
+RUN echo "14.0.0" > EXOMISER_VERSION.txt
+
 # Required to execute exomiser docker with nextflow
 ENTRYPOINT [  ]


### PR DESCRIPTION
This PR adds a file to the exomiser Docker image that contains the Exomiser version. This change will simplify the logic in the exomiser process for retrieving the exomiser version, which is currently fragile.

We will update the exomiser image in the exomiser process in a separate PR once the new exomiser image is properly published to the Docker registry.

**Local Tests**

I manually built the docker image locally.
Then I opened a shell on it and check that the EXOMISER_VERSION.txt file was present and that it's content is as expected

On another local branch, tested locally that the exomiser process can run with the new docker image and that we can use the EXOMISER_VERSION.txt file to obtain the exomiser version.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
