### PR TITLE
feat: Allow older GATK versions for test dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,8 @@ jobs:
 
         # Using the stub mode until our test data setup is ready
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -stub -profile test,docker --input assets/TestSampleSheet.csv
+          nextflow run ${GITHUB_WORKSPACE} -stub-run -profile test,docker --input "${GITHUB_WORKSPACE}/assets/TestSampleSheet.csv"
+
+      - name: Display nextflow.log on error
+        if: failure()
+        run: cat .nextflow.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.1.0dev - [date]
 
+### `Added`
+- [#35](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/35) Added allow_old_gatk_data parameter (set to false by default).
+- [#35](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/35) Added missing stub block in process writemeta for compatibility with latest nextflow version.
+- [#35](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/35) Improve github ci workflow to display nextflow log file content on error
+
+### `Fixed`
+- [#35](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/35) Fix incorrect assumption about assets folder location in github ci workflow
+
 
 ## v2.0.0dev
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -36,6 +36,7 @@ process {
 
     withName: GATK4_GENOTYPEGVCFS {
         container = 'broadinstitute/gatk:4.5.0.0'
+        ext.args = params.allow_old_gatk_data ? "--allow-old-rms-mapping-quality-annotation-data" : ""
         ext.prefix = {meta.id + ".genotyped"}
     }
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -12,7 +12,7 @@
     archive (.tar.gz) and extract it at the root of this  repository (tar -xzf <archive file>), you should 
     be able to run the pipeline with the following command:
 
-        nextflow -c data-test/test.config  run  Ferlab-Ste-Justine/Post-processing-Pipeline -r main -profile test,docker
+        nextflow run  Ferlab-Ste-Justine/Post-processing-Pipeline -r main -profile test,docker
     
 ----------------------------------------------------------------------------------------
 */
@@ -60,4 +60,7 @@ params {
     exomiser_remm_filename = "ReMM.v0.3.1.post1.hg38.tsv.gz"
     exomiser_analysis_wes = "${projectDir}/assets/exomiser/test_exomiser_analysis.yml"
     exomiser_analysis_wgs = "${projectDir}/assets/exomiser/test_exomiser_analysis.yml"
+
+    // To be able to run on our public test dataset, which is aligned with an older version of GATK4
+    allow_old_gatk_data = true
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,6 @@ params {
     exomiser_analysis_wes = "${projectDir}/assets/exomiser/default_exomiser_WES_analysis.yml"
     exomiser_analysis_wgs = "${projectDir}/assets/exomiser/default_exomiser_WGS_analysis.yml"
 
-
 	//Process-specific parameters
     TSfilterSNP = '99'
     TSfilterINDEL = '99'
@@ -45,6 +44,9 @@ params {
                    [name: 'MQ40', expression: 'MQ < 40.0'],
                    [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
                    [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']]
+    
+
+    allow_old_gatk_data = false
 	
 	//Resources optionsreferenceGenome
 	//defaults expecting to be overwritten

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -251,6 +251,11 @@
           "description": "Parameters for Hard-Filtering",
           "help_text": "Parameters for Hard-Filtering. Must be an array containing each desired filter. Each filter must be formatted with the desired name and expression, for example\\n[[name: 'QD1', expression: 'QD < 1.0'],[name: 'QD2', expression: 'QD < 2.0]]"
         },
+        "allow_old_gatk_data": {
+          "type": "boolean",
+          "description": "Allow the use of old GATK data in GATK_GENOTYPEGVCFS process by adding --allow-old-rms-mapping-quality-annotation-data to ext.args. Note: this won't work if ext.args is overridden.",
+          "help_text": "Allow the use of old GATK data in GATK_GENOTYPEGVCFS process by adding --allow-old-rms-mapping-quality-annotation-data to ext.args. Note that this won't work if ext.args is overridden. This parameter is not recommended for production use."
+        },
         "tools": {
           "type": "string",
           "pattern": "^(vep|exomiser)?(,(vep|exomiser))*$",
@@ -374,7 +379,10 @@
             "required": ["exomiser_cadd_version", "tools"]
           },
           "then": {
-            "required": ["exomiser_cadd_indel_filename", "exomiser_cadd_snv_filename"]
+            "required": [
+              "exomiser_cadd_indel_filename",
+              "exomiser_cadd_snv_filename"
+            ]
           }
         },
         {

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -192,6 +192,9 @@ def getPipelineInfoFolder(outdir) {
 // Check and validate pipeline parameters
 //
 def validateInputParameters() {
+    if (params.allow_old_gatk_data) {
+        log.warn "The 'allow_old_gatk_data' parameter is set to true, allowing the pipeline to run with older GATK data in GATK4_GENOTYPEGVCFS. Not recommended for production."
+    }
     genomeExistsError()
 }
 

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -104,6 +104,11 @@ process writemeta{
     Revision : ${workflow.revision}
     CommitId : ${workflow.commitId}
     """
+
+    stub:
+    """
+    touch metadata.txt
+    """
 }
 
 


### PR DESCRIPTION
**Description**
This PR introduces a new parameter `allow_old_gatk_data` and fixes issues in the CI workflow.

**Changes**
- **New Parameter: allow_old_gatk_data**: If set to true (default=false), older GATK version data will be tolerated in the GATK_GENOTYPEGVCFS process. This parameter is set to true in test.config as our public test dataset was aligned with an older GATK version. We maintain the default behavior in production to fail and log a warning.
- **CI Workflow Fixes**:
  - Fixed CI workflow failing on the latest Nextflow version by adding a missing stub block in the process writemeta.
  - Improved CI workflow to display the content .nextflow.log on error.
  - Fixed incorrect assumption about the assets folder location in the nextflow command

**Tests**

Test locally with the public dataset:
- `nextflow run main.nf -profile test,docker` : pipeline should complete successfully and warning should be logged
- `nextflow run main.nf -profile test,docker --allow_old_gatk_data=false`: pipeline should fail at genotype gvcfs step
-  comment the parameter set to true in test.config and re-run  `nextflow run main.nf -profile test,docker`. The pipeline should fail at genotype gvcfs step

Test on juno:
- Edit file paramsJuno.json  in test dataset to set the `allow_old_gatk_data` parameter to true, then run this command:
`nextflow -c /root/nextflow/config/fusion.config run Ferlab-Ste-Justine/Post-processing-Pipeline -r feat/allow-older-gatk-versions-for-test-dataset -params-file data-test/paramsJuno.json   -work-dir 's3://cqdg-prod-file-scratch/nextflow/scratch/lysiane`
 Pipeline should complete successfully

The public test dataset copies in juno have been updated to incorporate changes in file paramJuno.json. Since these changes are not breaking, it kept the same dataset version (V3).

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
