### PR TITLE
fix: CLIN-2947 make resume work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 - [#35](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/35) Fix incorrect assumption about assets folder location in github ci workflow
-
+- [#36](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/36) Fix variable input in process BCFTOOLS_NORM causing resume problems
 
 ## v2.0.0dev
 

--- a/subworkflows/local/exclude_mnps/main.nf
+++ b/subworkflows/local/exclude_mnps/main.nf
@@ -17,8 +17,7 @@ workflow EXCLUDE_MNPS {
 
     def ch_bcftoolsfilter_for_bcftoolsnorm = BCFTOOLS_FILTER.out.vcf.join(BCFTOOLS_FILTER.out.tbi)
 
-    ch_reference = input.map{meta,file -> [meta,reference_path]}
-    BCFTOOLS_NORM(ch_bcftoolsfilter_for_bcftoolsnorm,ch_reference)
+    BCFTOOLS_NORM(ch_bcftoolsfilter_for_bcftoolsnorm, [[:], reference_path])
     ch_output_excludemnps = BCFTOOLS_NORM.out.vcf.join(BCFTOOLS_NORM.out.tbi)
         .map{meta, vcf, tbi ->[meta,[vcf,tbi]]}
 


### PR DESCRIPTION
 Fix variable input in process BCFTOOLS_NORM causing resume problems
 See https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/issues/31

**Test**

I run the following commands locally. In the second command (with resume), as expected, all process were marked as "cached", except for the writemeta. 
```
nextflow run main.nf -profile docker,test
nextflow run main.nf -profile docker,test -resume
```

I did the equivalent in juno:
```
kubectl exec -it -n cqdg-prod deploy/nextflow -- /bin/bash

 cd  pipeline/dev/Post-processing-Pipeline/
 
nextflow -c /root/nextflow/config/fusion.config run Ferlab-Ste-Justine/Post-processing-Pipeline -r fix/clin-2947-make-resume-work-again -params-file data-test/paramsJuno.json -work-dir 's3://cqdg-prod-file-scratch/nextflow/scratch/lysiane'  
        
nextflow -c /root/nextflow/config/fusion.config run Ferlab-Ste-Justine/Post-processing-Pipeline -r fix/clin-2947-make-resume-work-again -params-file data-test/paramsJuno.json -work-dir 's3://cqdg-prod-file-scratch/nextflow/scratch/lysiane'  -resume
```

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
