### PR TITLE
feat: CLIN-3614 add docker image for exomiser 13.1.0

### DIFF
--- a/.github/workflows/publish_with_latest.yml
+++ b/.github/workflows/publish_with_latest.yml
@@ -21,16 +21,30 @@ jobs:
           dockerfile: containers/nextflow/Dockerfile
           tag_format: "latest"
   push-exomiser:
-      name: Publish Exomiser Image using latest tags
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-        - name: Push the image on the registry
-          uses: Ferlab-Ste-Justine/action-push-image@v2
-          with:
-            username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
-            password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
-            image: ferlabcrsj/exomiser
-            location: containers/exomiser
-            dockerfile: containers/exomiser/Dockerfile
-            tag_format: "latest"
+    name: Publish Exomiser Image using latest tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/exomiser
+          location: containers/exomiser
+          dockerfile: containers/exomiser/Dockerfile
+          tag_format: "latest"
+  push-exomiser-13:
+    name: Publish Exomiser 13.1.0 Image using latest tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/exomiser
+          location: containers/exomiser-13
+          dockerfile: containers/exomiser-13/Dockerfile
+          tag_format: "13.1.0-latest"

--- a/.github/workflows/publish_with_semver_tag.yml
+++ b/.github/workflows/publish_with_semver_tag.yml
@@ -34,3 +34,17 @@ jobs:
             location: containers/exomiser
             dockerfile: containers/exomiser/Dockerfile
             tag_format: "{semver}"
+  push-exomiser-13:
+        name: Publish Exomiser 13.1.0 Image using tags
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - name: Push the image on the registry
+            uses: Ferlab-Ste-Justine/action-push-image@v2
+            with:
+              username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+              password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+              image: ferlabcrsj/exomiser
+              location: containers/exomiser-13
+              dockerfile: containers/exomiser-13/Dockerfile
+              tag_format: "13.1.0-{semver}"

--- a/.github/workflows/publish_with_sha.yml
+++ b/.github/workflows/publish_with_sha.yml
@@ -21,16 +21,30 @@ jobs:
           dockerfile: containers/nextflow/Dockerfile
           tag_format: "{sha}-{timestamp}"
   push-exomiser:
-      name: Publish Exomiser Image using commit sha and timestamp
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-        - name: Push the image on the registry
-          uses: Ferlab-Ste-Justine/action-push-image@v2
-          with:
-            username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
-            password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
-            image: ferlabcrsj/exomiser
-            location: containers/exomiser
-            dockerfile: containers/exomiser/Dockerfile
-            tag_format: "{sha}-{timestamp}"
+    name: Publish Exomiser Image using commit sha and timestamp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/exomiser
+          location: containers/exomiser
+          dockerfile: containers/exomiser/Dockerfile
+          tag_format: "{sha}-{timestamp}"
+  push-exomiser-13:
+    name: Publish Exomiser 13.1.0 Image using commit sha and timestamp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/exomiser
+          location: containers/exomiser-13
+          dockerfile: containers/exomiser-13/Dockerfile
+          tag_format: "13.1.0-{sha}-{timestamp}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#41](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/41) Allow to customize the vep command
 - [#41](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/41) Improve parameter schema for params max_disk, max_memory, max_time
 - [#41](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/41) Consider only stable nextflow versions for ci test
+- [#42](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/42) Add docker image for exomiser 13.1.0
 
 ### `Known issues`
 - The nf-core modules that we are using have a potential performance flaw. Typically, the regex used to describe the output files also match the input files (ex: "*.vcf"), which can cause unnecessary file transfers.  This has already proven to cause issues on fusion. One fix could be to transfer the whole modules to local to perform the small change necessary to fix this.
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### `Fixed`
-- [#51](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/41) Fix vep url pointing to the wrong vep version in the reference data documentation.
+- [#41](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/41) Fix vep url pointing to the wrong vep version in the reference data documentation.
 
 ## v2.1.0dev
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -6,7 +6,14 @@ utilities such as the AWS CLI and Rclone. Additionally, it provides more basic l
 not included in the base nextflow image.
 
 ### Exomiser
-This Docker image is based on the official Exomiser Docker image. It includes Exomiser tools but modifies the entrypoint to work with Nextflow on Kubernetes.
+
+This Docker image is based on the official exomiser Docker image exomiser exomiser-cli:14.0.0-bash. 
+It is modified for compatibility with nextflow.
+
+### Exomiser-13
+
+This is a docker image allowing to run exomiser 13.1.0. One can substitute the resulting image with our default
+exomiser image to run the pipeline with exomser 13.1.0.
 
 ## Local Testing Commands
 Here is an example for the Nextflow image. You can adapt these commands for other images as needed.

--- a/containers/exomiser-13/Dockerfile
+++ b/containers/exomiser-13/Dockerfile
@@ -1,0 +1,42 @@
+ARG EXOMISER_VERSION=13.1.0
+
+# -------------------------------------------------------------------------- #
+# Stage 1: using the distroless image to obtain exomiser distribution files  #
+#                                                                            #
+# We are using this image to guarantee the same packaging strategy as        #
+# in other exomiser-cli images                                               #
+# -------------------------------------------------------------------------- #
+FROM exomiser/exomiser-cli:${EXOMISER_VERSION} AS builder
+
+
+# -------------------------------------------------------------- #
+# Stage 2: Create an image similar to exomiser cli bash images   #
+#                                                                #
+# We replicate only the necessary logic to launch the same java  #
+# command as in other Exomiser images.                           #
+# -------------------------------------------------------------- #
+
+FROM eclipse-temurin:17.0.6_10-jre AS exomiser-cli-bash
+
+COPY --from=builder /app /app
+
+
+# ---------------------------------- #
+# Stage 3: Add nextflow requirements #
+# ---------------------------------- #
+
+FROM exomiser-cli-bash
+
+ARG EXOMISER_VERSION
+
+# Adding ps to the container (required by nextflow)
+RUN apt-get update && \
+    apt-get install -y procps=2:3.3.17-6ubuntu2.1 && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Create a file containing the exomiser version, as there is no way to retrieve it from the exomiser-cli.
+RUN echo ${EXOMISER_VERSION} > EXOMISER_VERSION.txt
+
+# Required to execute exomiser docker with nextflow
+ENTRYPOINT [  ]


### PR DESCRIPTION
Ajout d'une image docker supplémentaire pour supporter exomiser 13.1.0.

Il sera possible de remplacer simplement l'image par défaut par cette nouvelle image dans la configuration Nextflow pour le processus EXOMISER. Le script exomiser sera alors exécuté avec exomiser 13.1.0 au lieu d'exomiser 14.0.0.

**Implémentation**

J'ai rencontré des difficultés car l'image Docker disponible pour cette version est différente des autres.

À partir de la version 13.2, exomiser fournit une image de type "bash", plus adaptée à nextflow. C'est cette image que nous avions utilisée pour créer notre image exomiser par défaut (14.0.0).

Pour la version 13.1.0, il n'y a qu'une image de type "distroless". J'ai donc créé une image qui réplique autant que possible l'image bash des autres versions. Les images bash et distroless semblent utiliser la même stratégie de packaging java. J'ai simplement copié le dossier contenant les ressources java (.jar, .class, etc.) dans une autre image qui, selon le code source, serait l'image de base utilisée pour les images bash.

**Tests**

J'ai créé l'image localement. Ex:
`sudo docker build containers/exomiser-13 -t ferlabcrsj/exomiser13:dev`

Ensuite, j'ai roulé le pipeline sur notre jeu de données public en utilisant cette image:
`nextflow -c test_exomiser.config run main.nf -profile test,docker`

J'ai dû télécharger une version plus ancienne des données de référence (2109) parce que celles qu'on a dans notre jeu de données de test public (2402) semblent trop récentes pour exomiser 13.1.0. Voici le contenu du fichier test_exomiser.config:
```
params {
    exomiser_data_dir = "data-test/reference/exomiser13"
    exomiser_data_version = "2109"
}

process {
   withName: EXOMISER { 
        container = 'ferlabcrsj/exomiser-13:dev'
   }
}
```

Exomiser a pris beaucoup de temps à compléter sur ma machine (environ 1h), mais la commande a réussi.

J'ai vérifié le fichier versions.yml dans le work directory du process. Il semble bien créé et contenir la bonne version d'exomiser, soit 13.1.0.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
