### PR TITLE
fix: CLIN-3610 use container tag 1.20 instead latest for split multia…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#49](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/49) Add support for local frequency source
 - [#49](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/49) Pass java -Xmx option at the command line for exomiser
 
+### `Fixed`
+- [#50](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/50) Use container tag 1.20 for splitMultiAllelics process
+
 ### `Known issues`
 - The nf-core modules that we are using have a potential performance flaw. Typically, the regex used to describe the output files also match the input files (ex: "*.vcf"), which can cause unnecessary file transfers.  This has already proven to cause issues on fusion. One fix could be to transfer the whole modules to local to perform the small change necessary to fix this.
 - The VEP cache version used in the CQDG environment (112) does not match the default configured VEP version (111). This issue can be avoided by overriding the Docker container of the ensemblevep process. If no project is using VEP version 111, it should not be used as the default value.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -95,6 +95,7 @@ process {
     }
 
     withName: 'splitMultiAllelics' {
+        container = 'staphb/bcftools:1.20'
         publishDir = new_publish_dir([enabled: true])
     }
 }

--- a/modules/local/split_multi_allelics.nf
+++ b/modules/local/split_multi_allelics.nf
@@ -1,9 +1,7 @@
 // This module does not follow nf-core standards. We plan to fix or replace it with an nf-core module in the future.
 process splitMultiAllelics{
-    label 'medium'
+    label 'process_medium'
 
-    container 'staphb/bcftools'
-    
     input:
     tuple val(meta), path(vcfFile)
     path referenceGenome


### PR DESCRIPTION
We are currently using the "latest" tag for the bcftools container in the SplitMultiAllelics process.

To make the pipeline more stable and reproducible, we will use a specific tag instead (1.20). We used the same version as other processes based on bcftools.

**Tests**

Run the pipeline locally on this branch and on the main branch:
`nextflow run main.nf -profile test,docker`

Compare the output for the splitMultiAllelics process. The bodies of the vcf files should be identical.

On the current branch, open the nextflow execution report (pipeline info output folder) and double check that the container is bcftools:1.20

**Juno tests**

Run the pipeline in juno. Make sure that the container used if bcftools:1.20 and not bcftools:latest.

**Linter Warnings**

For the linter, we still see the warning `Container versions do not match` for the split_multi_allelics module, which is also present on the main branch. We thought simply removing the container definition in the module would fix it, but it doesn't.  We will not address this problem in the present PR. We shall revisit this later when standardizing the module.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
