### PR TITLE
fix: CLIN-3453 add missing resources for exomiser process in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 - [#50](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/50) Use container tag 1.20 for splitMultiAllelics process
+- [#51](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/51) Add missing ressources for exomiser process in configuration
 
 ### `Known issues`
 - The nf-core modules that we are using have a potential performance flaw. Typically, the regex used to describe the output files also match the input files (ex: "*.vcf"), which can cause unnecessary file transfers.  This has already proven to cause issues on fusion. One fix could be to transfer the whole modules to local to perform the small change necessary to fix this.

--- a/modules/local/exomiser/main.nf
+++ b/modules/local/exomiser/main.nf
@@ -1,6 +1,6 @@
 process EXOMISER {
 
-    label 'process_low'
+    label 'process_medium'
  
     input:
     tuple val(meta), path(vcfFile), path(phenoFile), path(analysisFile)

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,7 +58,7 @@ params {
 	//Resources optionsreferenceGenome
 	//defaults expecting to be overwritten
 	max_cpus = 16
-	max_disk = '80.GB'
+	max_disk = '200.GB'
 	max_time = '12.h'
 	max_memory = '120.GB'
 
@@ -223,7 +223,8 @@ env {
 }
 
 process {
-  disk = 40.GB
+    disk = 40.GB
+
 	withName: 'variantRecalibratorSNP|variantRecalibratorIndel|applyVQSRIndel|applyVQSRSNP|gatherVCF' {
 		container = 'broadinstitute/gatk:4.5.0.0'
 	}
@@ -295,6 +296,14 @@ process {
 		disk	=	{ check_max( 80.GB	* task.attempt, 'disk'		)	}
 		time	=	{ check_max( 10.h 	* task.attempt, 'time'		)	}
 	}
+    withName: 'EXOMISER' {
+        errorStrategy = 'retry'
+		maxRetries = 2
+		cpus	=	{ check_max( 6 		* task.attempt, 'cpus'		)	}
+		memory	=	{ check_max( 36.GB	* task.attempt, 'memory'	)	}
+		disk	=	{ check_max( 150.GB	* task.attempt, 'disk'		)	}
+		time	=	{ check_max( 10.h 	* task.attempt, 'time'		)	}
+    }
     withName: 'writemeta' {
         container = 'ubuntu:24.10'	
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -170,7 +170,7 @@
         },
         "max_disk": {
           "type": "string",
-          "default": "80.GB",
+          "default": "200.GB",
           "description": "Maximum amount of disk space that can be requested for any single job.",
           "pattern": "^\\d+(\\.\\d+)?\\.?\\s*(K|M|G|T)?B$",
           "help_text": "Use to set an upper-limit for the disk space requirement for each process. Should be a string in the format integer-unit e.g. `--max_disk '8.GB'`"


### PR DESCRIPTION
This pull request adds default resource values for the exomiser process. The values are based on realistic exomiser reference data used in the QLIN environment.

While it may be possible to reduce resource requirements when using fewer exomiser data sources, we aim to provide defaults that are likely to work in most cases. These defaults should give users a good idea of the requirements for a production deployment.

**Tests**

Run the pipeline locally:
`nextflow run main.nf -profile test,docker`

**Juno Tests**

Run the pipeline in Juno. Check that the allocated resources on the exomiser pod are matching the configuration.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
