### PR TITLE
feat: CLIN-3713 allow exomiser to start from vep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#49](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/49) Add support for local frequency source
 - [#49](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/49) Pass java -Xmx option at the command line for exomiser
 - [#53](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/53) Replace vep and tabix logic by a standard nf-core subworkflow
+- [#54](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/54) Allow exomiser to start from the vep output
+
+### `Changed`
+- [#54](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/54) Standardize exomiser output filenames
 
 ### `Fixed`
 - [#50](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/50) Use container tag 1.20 for splitMultiAllelics process

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -68,6 +68,7 @@ process {
             enabled: true,
             pattern: 'results/*{vcf.gz,vcf.gz.tbi,tsv,json,html}'
         ])
+        ext.args = { "--output-filename=${meta.id}.exomiser" }
     }
 
     withName: ENSEMBLVEP_VEP {

--- a/docs/output.md
+++ b/docs/output.md
@@ -109,22 +109,22 @@ The `exomiser/results` subdirectory contains the output fo the pipeline after th
 
 ```
 |_ exomiser/results
-   |_ family1.splitted-exomiser.genes.tsv
-   |_ family1.splitted-exomiser.html
-   |_ family1.splitted-exomiser.json
-   |_ family1.splitted-exomiser.variants.tsv
-   |_ family1.splitted-exomiser.vcf.gz
-   |_ family1.splitted-exomiser.vcf.gz.tbi
+   |_ family1.exomiser.genes.tsv
+   |_ family1.exomiser.html
+   |_ family1.exomiser.json
+   |_ family1.exomiser.variants.tsv
+   |_ family1.exomiser.vcf.gz
+   |_ family1.exomiser.vcf.gz.tbi
   ...   
 ```
 
 It should contains a set of 6 files per family.  Specifically, we use the following naming scheme:
-- `<FAMILY_ID>.splitted-exomiser.genes.tsv`
-- `<FAMILY_ID>.splitted-exomiser.html`
-- `<FAMILY_ID>.splitted-exomiser.json`
-- `<FAMILY_ID>.splitted-exomiser.variants.tsv`
-- `<FAMILY_ID>.splitted-exomiser.vcf.gz`
-- `<FAMILY_ID>.splitted-exomiser.vcf.gz.tbi`
+- `<FAMILY_ID>.exomiser.genes.tsv`
+- `<FAMILY_ID>.exomiser.html`
+- `<FAMILY_ID>.exomiser.json`
+- `<FAMILY_ID>.exomiser.variants.tsv`
+- `<FAMILY_ID>.exomiser.vcf.gz`
+- `<FAMILY_ID>.exomiser.vcf.gz.tbi`
 
 The family ID should match the family ID in the input sample sheet.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -98,6 +98,14 @@ Exomiser, on the other hand, is a tool specifically designed for the analysis of
 integrates phenotype data with variant information to prioritize variants that are likely to be disease-causing. 
 This can greatly assist in the identification of potential disease-causing variants in exome sequencing data.
 
+### Exomiser input data
+
+By default, both vep and exomiser steps, if applicable, run in parallel and consume the output of the normalization step.
+
+To have the Exomiser step start from the VEP output instead, set the parameter `exomiser_start_from_vep` to `true`. In this case, the vep and exomiser steps will run sequentially.
+
+Note that the parameter `exomiser_start_from_vep` will be ignored if vep is not specified via the `tools` parameter.
+
 ### Customize versions and commands
 
 If needed, it is possible to customize the options passed to the vep command by overriding the ext.args directive for the
@@ -188,3 +196,4 @@ Parameters summary
 | `exomiser_remm_filename` | _Optional_	| Filename of the exomiser REMM data file (e.g., `ReMM.v0.3.1.post1.hg38.tsv.gz`) |
 | `exomiser_analysis_wes` | _Optional_ | Path to the exomiser analysis file for WES data, if different from the default |
 | `exomiser_analysis_wgs` | _Optional_ | Path to the exomiser analysis file for WGS data, if different from the default |
+| `exomiser_start_from_vep` | _Optional_ | If `true` (default `false`), run the exomiser analysis on the VEP annotated VCF file. Ignored if vep is not activated via `tools` parameter. |

--- a/modules/local/exomiser/tests/main.nf.test
+++ b/modules/local/exomiser/tests/main.nf.test
@@ -17,9 +17,10 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [familyId: "family1"],
-                 file("https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz"), 
-                 file("assets/exomiser/pheno/family1.yml"),
-                 file("assets/exomiser/default_exomiser_WGS_analysis.yml")]
+                file("https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz"), 
+                file("https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi"), 
+                file("assets/exomiser/pheno/family1.yml"),
+                file("assets/exomiser/default_exomiser_WGS_analysis.yml")]
                 input[1] = file("data-test/reference/exomiser")
                 input[2] = "hg38"
                 input[3] = "2402"
@@ -37,32 +38,32 @@ nextflow_process {
                 // vcf channel
                 assert vcf.size() == 1
                 assert vcf.get(0)[0] == expected_meta
-                assert file(vcf.get(0)[1]).name == "family1.splitted-exomiser.vcf.gz"
+                assert file(vcf.get(0)[1]).name == "family1.exomiser.vcf.gz"
 
                 // tbi channel
                 assert tbi.size() == 1
                 assert tbi.get(0)[0] == expected_meta
-                assert file(tbi.get(0)[1]).name == "family1.splitted-exomiser.vcf.gz.tbi"
+                assert file(tbi.get(0)[1]).name == "family1.exomiser.vcf.gz.tbi"
 
                 // html channel
                 assert html.size() == 1
                 assert html.get(0)[0] == expected_meta
-                assert file(html.get(0)[1]).name == "family1.splitted-exomiser.html"
+                assert file(html.get(0)[1]).name == "family1.exomiser.html"
 
                 // json channel
                 assert json.size() == 1
                 assert json.get(0)[0] == expected_meta
-                assert file(json.get(0)[1]).name == "family1.splitted-exomiser.json"
+                assert file(json.get(0)[1]).name == "family1.exomiser.json"
 
                 // genetsv channel
                 assert genetsv.size() == 1
                 assert genetsv.get(0)[0] == expected_meta
-                assert file(genetsv.get(0)[1]).name == "family1.splitted-exomiser.genes.tsv"
+                assert file(genetsv.get(0)[1]).name == "family1.exomiser.genes.tsv"
 
                 // variantstsv channel
                 assert variantstsv.size() == 1
                 assert variantstsv.get(0)[0] == expected_meta
-                assert file(variantstsv.get(0)[1]).name == "family1.splitted-exomiser.variants.tsv"
+                assert file(variantstsv.get(0)[1]).name == "family1.exomiser.variants.tsv"
 
                 // versions channel
                 assert snapshot(versions).match()

--- a/modules/local/split_multi_allelics.nf
+++ b/modules/local/split_multi_allelics.nf
@@ -7,7 +7,7 @@ process splitMultiAllelics{
     path referenceGenome
 
     output:
-    tuple val(meta), path("*splitted.vcf*")
+    tuple val(meta), path("*splitted.vcf.gz"), path("*splitted.vcf.gz.tbi")
 
     script:
     def familyId = meta.familyId

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,7 @@ params {
     exomiser_analysis_wgs = "${projectDir}/assets/exomiser/default_exomiser_WGS_analysis.yml"
     exomiser_local_frequency_path = null
     exomiser_local_frequency_index_path = null
+    exomiser_start_from_vep = false
 
 	//Process-specific parameters
     exclude_mnps = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -401,6 +401,11 @@
           "description": "Path to the index of the local frequency data file",
           "format": "file-path",
           "pattern": "^\\S+\\.tbi$"
+        },
+        "exomiser_start_from_vep": {
+          "type": "boolean",
+          "description": "If true, run the exomiser analysis on the VEP annotated VCF file",
+          "default": false
         }
       },
       "allOf": [


### PR DESCRIPTION
This pull request introduces the option to start exomiser from the vep-annotated vcf file instead of the normalized vcf file.

We add the `exomiser_start_from_vep` parameter. When set to `true` (default is `false`), exomiser will start from the vep-annotated vcf file.

If vep is not included in the tools parameter, the `exomiser_start_from_vep` parameter will be ignored, and exomiser will start from the normalized vcf file (default behavior).

We also standardize the exomiser output file names in the module configuration to ensure consistent filenames regardless of the input used.

**Tests**

Run the pipeline locally and check that vep output does not change in comparison to the main branch.
Check that the files in the exomiser output folder are named as expected
With bcftools view -H command, inspect the body of one exomiser output vcf file. We should NOT see the vep CSQ key in the INFO column.

Run the pipeline locally, this time specifying --exomiser_start_from_vep true. 
Check that the files in the exomiser output folder are named as expected
With bcftools view -H command, inspect the body of one exomiser output vcf file. We should see the CSQ key in the INFO column.

Run the pipeline locally, this time  specifying --exomiser_start_from_vep true --tools exomiser
Check that the files in the exomiser output folder are named as expected
With bcftools view -H command, inspect the body of one exomiser output vcf file. We should NOT see the vep CSQ key in the INFO column.

Replicate the 3 scenarios in juno and inspect one exomiser output vcf file. See if we see the vep CSQ key or not.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
