### PR TITLE
fix: CLIN-2414 allow to pass exomiser spring options in task.ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.4.0-dev - [date]
 
+### `Fixed`
+- [#57](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/57) Allow to pass exomiser application properties
+
 ## v2.3.0-dev
 
 ### `Added`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,6 +106,16 @@ To have the Exomiser step start from the VEP output instead, set the parameter `
 
 Note that the parameter `exomiser_start_from_vep` will be ignored if vep is not specified via the `tools` parameter.
 
+### Exomiser CLI options
+
+We typically allow passing extra arguments in our process scripts via the process `task.ext` directive (`task.ext.args` key).
+
+When using the exomiser process, it's important to distinguish between regular CLI options and options that correspond to properties normally specified in the application.properties file.
+
+Regular CLI options should be added to `task.ext.args`.
+
+Options that correspond to application properties (e.g., typically `--exomiser.some-property=value`) must be added to `task.ext.application_properties_args`. These options need to be grouped at the end of the exomiser command to ensure that regular exomiser cli options are parsed correctly.
+
 ### Customize versions and commands
 
 If needed, it is possible to customize the options passed to the vep command by overriding the ext.args directive for the

--- a/modules/local/exomiser/main.nf
+++ b/modules/local/exomiser/main.nf
@@ -33,6 +33,7 @@ process EXOMISER {
 
     script:
     def args = task.ext.args ?: ''
+    def applicationPropertiesArgs = task.ext.application_properties_args ?: ''
 
     def localFrequencyFileArgs = "" 
     if (localFrequencyPath) {
@@ -67,18 +68,19 @@ process EXOMISER {
     #!/bin/bash -eo pipefail
 
     java -Xmx${avail_mem}M -cp \$( cat /app/jib-classpath-file ) \$( cat /app/jib-main-class-file ) \\
-        ${args} \\
         --vcf ${vcfFile} \\
         --assembly "${params.exomiser_genome}" \\
         --analysis "${analysisFile}" \\
         --sample ${phenoFile} \\
         --output-format=HTML,JSON,TSV_GENE,TSV_VARIANT,VCF \\
+        ${args} \\
         --exomiser.data-directory=/`pwd`/${datadir} \\
         ${localFrequencyFileArgs} \\
         ${remmArgs} \\
         ${caddArgs} \\
         --exomiser.${exomiserGenome}.data-version="${exomiserDataVersion}" \\
-        --exomiser.phenotype.data-version="${exomiserDataVersion}"
+        --exomiser.phenotype.data-version="${exomiserDataVersion}" \\
+        ${applicationPropertiesArgs}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
It appears that exomiser options overriding properties in application.properties must be passed at the end of the exomiser command. Any command-line options specified after these overrides seem to be ignored, causing various buggy behaviors.

We have observed a specific instance of this problem before but were not aware of the precise cause. To avoid this issue, we initially decided to pass task.ext.args at the beginning of the command. However, this fix has caused other problems in different contexts, particularly in QLIN, where passing an application property is required.

This PR allows passing both regular CLI options and options for application properties. We will use two different task.ext keys.

**Manual Tests**

- Run the pipeline in the Qlin environment, using exomiser 13.1.0, with realistic configuration files, as will be done when integrating the pipeline in the qlin etl.  The exomiser process now runs correctly and we can see the exomiser files correctly in the output folder. ✅ 

- Run the pipeline locally, i.e. with `nextflow run main.nf -profile test,docker`. The pipeline runs successfully. We see the exomiser output files in the output folder.  ✅ 
- Repeat the same test in Juno ✅ 

- By default, we don't override exomiser application properties when using the test profile. We passed an extra configuration file with the following content: 
```
process {
 withName: EXOMISER { 
        ext.application_properties_args = { "--logging.file.name=results/logs.exomiser.json" }
 }
}
```
The pipeline should run successfully and we should see the file logs.exomiser.json in exomiser output folder. ✅ 
- Repeat the same test in Juno ✅ 

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
