### PR TITLE
Adding "snv" to prefix of VEP output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 - [#54](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/54) Standardize exomiser output filenames
+- [#59](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/59) Add ".snv" to VEP output filename prefix
 
 ### `Fixed`
 - [#50](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/50) Use container tag 1.20 for splitMultiAllelics process

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -89,7 +89,7 @@ process {
             "--fields \"Allele,Consequence,IMPACT,SYMBOL,Feature_type,Gene,PICK,Feature,EXON,BIOTYPE,INTRON,HGVSc,HGVSp,STRAND,CDS_position,cDNA_position,Protein_position,Amino_acids,Codons,VARIANT_CLASS,HGVSg,CANONICAL,RefSeq\""
         ]
         ext.args = args_list.join(" ")
-        ext.prefix =  {"variants.${meta.id}.vep"}
+        ext.prefix =  {"variants.${meta.id}.snv.vep"}
     }
 
     withName: '.*VCF_ANNOTATE_ENSEMBLVEP.*' {

--- a/docs/output.md
+++ b/docs/output.md
@@ -92,14 +92,14 @@ The `ensemblvep` subdirectory contains the output of the pipeline after the vep 
 
 ```
 |_ ensemblvep/
-  |_ variants.family1.vep.vcf.gz
-  |_ variants.family1.vep.vcf.gz.tbi
+  |_ variants.family1.snv.vep.vcf.gz
+  |_ variants.family1.snv.vep.vcf.gz.tbi
   ...
 ```
 
 It contains one pair of `vcf.gz`, `vcf.gz.tbi` files per family. Specifically, we use the following naming scheme:
-- `variants.<FAMILY_ID>.vep.vcf.gz`
-- `variants.<FAMILY_ID>.vep.vcf.gz.tbi`
+- `variants.<FAMILY_ID>.snv.vep.vcf.gz`
+- `variants.<FAMILY_ID>.snv.vep.vcf.gz.tbi`
 
 The family ID should match the family ID in the input sample sheet.
 


### PR DESCRIPTION
## Background

CQDG team requested for the filenames to specify the type of data (on top of the format). This would allow them to differentiate in the future the VCFs containing SVs, CNVs and SNVs (SNPs and Indels).

## Description of changes:
- Output prefixes for each module are defined in the `modules.config` file as `ext.prefix` or in `ext.args`. For VEP, it is passed as `ext.prefix`. 
- For now, the only name change would be in the name of the annotated VCF: `variants.${meta.id}.vep.vcf.gz` -> `variants.${meta.id}.snv.vep.vcf.gz`

## Tests
1. Test dataset in Juno, default test params
  [x] vet output filename changed correctly.
  [x] exomiser ran without issues. 
  [x] outputs match tests runs with previous tags.

3. Test dataset in Juno, test params + setting `-exomiser_start_from_vep` to `true`
  [x] vet output filename changed correctly
  [x] exomiser ran from vep without issues. 
  [x] outputs match tests runs with previous tags.

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
