### PR TITLE
Bump version to v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
-# ferlab/postprocessing: Changelog
+# ferlab/Post-Processing-Pipeline: Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased 
+## Unreleased
+
+## v2.5.0 - <small>2025-01-30</small>
 
 ### `Added`
-- [#61](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/61) Add download VEP module form nf-core
+- [#61](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/61) Add download VEP module form nf-core. Addresses [#BIOINFO-20](https://ferlab-crsj.atlassian.net/browse/BIOINFO-20), no cache version issues were found.
 
 ### `Changed`
 - [#59](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/59) Add ".snv" to VEP output filename prefix
   
-## v2.4.1-dev - 16/01/2025
+### `Deprecated`
+- Changelog versioning format vx.y.z-dev is deprecated as of now. We will now keep an [Unreleased section](#unreleased) at the top to track upcoming changes. When bumping the version, move the Unreleased section changes under the new version section. Listed changes will now be associated with the specific tag.
+
+## v2.4.1-dev - <small>2025-01-16</small>
 
 ## v2.4.0-dev
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This schema was done using [inkscape](https://inkscape.org/) with the good prati
 Here is an example nextflow command to run the pipeline:
 
 ```bash
-nextflow run -c cluster.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "v2.4.1" \
+nextflow run -c cluster.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "2.5.0" \
     -params-file params.json  \
    --input samplesheet.csv \
    --outdir results/dir \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,15 +12,15 @@ The Ferlab-Ste-Justine/Post-processing-Pipeline is a bioinformatics pipeline des
 
 ## Samplesheet input
 
-You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use the `--input` parameter to specify its location. The samplesheet has to be a comma separated file (.csv).
+You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use the `--input` parameter to specify its location. The samplesheet has to be a comma separated file (`.csv`).
 
 The samplesheet must contains the following columns at the minimum: 
 - *familyId*: The identifier used for the sample family
 - *sample*: The identifier used for the sample
 - *sequencingType*: Must be either WES (Whole Exome Sequencing) or WGS (Whole Genome Sequencing)
-- *gvcf*: Path to the sample .gvcf.gz file
+- *gvcf*: Path to the sample `.gvcf.gz` file
 
-Additionnally, there is an optional *phenoFamily* column that can contain a .yml/.json file providing phenotype 
+Additionally, there is an optional *phenoFamily* column that can contain a `.yml/.json` file providing phenotype 
 information on the family in phenopacket format. This column is only necessary if using the exomiser tool.
 
 
@@ -54,7 +54,7 @@ These files must be correctly downloaded and specified through pipeline paramete
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run -c cluster.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "v2.4.1" \
+nextflow run -c fusion.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "v2.5.0" \
     -params-file params.json  \
    --input samplesheet.csv \
    --outdir results/dir \
@@ -73,9 +73,8 @@ work                # Directory containing the nextflow working files
 
 If you wish to repeatedly use the same parameters for multiple runs, rather than specifying each flag in the command, you can specify these in a params file (json or yaml).
 
-:::warning
+> <b>WARNING</b>:  
 Do not use `-c <file>` to specify parameters as this will result in errors. Custom config files specified with `-c` must only be used for [tuning process resource specifications](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources), other infrastructural tweaks (such as output directories), or module arguments (args).
-:::
 
 ### Skip exclude MNPs
 
@@ -136,22 +135,22 @@ For tests with real data, see documentation in the [test configuration profile](
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
 
 ```bash
-nextflow pull ferlab/postprocessing
+nextflow pull Ferlab-Ste-Justine/Post-processing-Pipeline
 ```
 
 ### Reproducibility
 
 It is a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [ferlab/postprocessing releases page](https://github.com/ferlab/postprocessing/releases) and find the latest pipeline version - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`. Of course, you can switch to another version by changing the number after the `-r` flag.
+First, go to the [Ferlab-Ste-Justine/Post-processing-Pipeline releases page](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/tags) and find the latest pipeline version - numeric only (eg. `2.5.0`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 2.5.0`. Of course, you can switch to another version by changing the number after the `-r` flag.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future. For example, at the bottom of the MultiQC reports.
 
-To further assist in reproducbility, you can use share and re-use [parameter files](#running-the-pipeline) to repeat pipeline runs with the same settings without having to write out a command with every single parameter.
+To further assist in reproducibility, you can use share and re-use [parameter files](#running-the-pipeline) to repeat pipeline runs with the same settings without having to write out a command with every single parameter.
 
-:::tip
+> <b>TIP</b>:  
 If you wish to share such profile (such as upload as supplementary material for academic publications), make sure to NOT include cluster specific paths to files, nor institutional specific profiles.
-:::
+
 
 
 ### Core Nextflow arguments

--- a/nextflow.config
+++ b/nextflow.config
@@ -394,7 +394,7 @@ manifest {
     description     = """Variant analysis for genome and exome GVCFs"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.10.1'
-    version         = '2.4.1-dev'
+    version         = '2.5.0'
     doi             = ''
 }
 


### PR DESCRIPTION
Bumping to v2.5.0, which adds the nf-core module ensemblvep-download.

!! Note that exomiser container version has been left as 2.4.1 for the moment. 

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
