### PR TITLE
feat: CLIN-3414 bump version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased
+
+## v2.6.0 - <small>2025-02-07</small>
 
 ### `Added`
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This schema was done using [inkscape](https://inkscape.org/) with the good prati
 Here is an example nextflow command to run the pipeline:
 
 ```bash
-nextflow run -c cluster.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "2.5.0" \
+nextflow run -c cluster.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "v2.6.0" \
     -params-file params.json  \
    --input samplesheet.csv \
    --outdir results/dir \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,7 +51,7 @@ These files must be correctly downloaded and specified through pipeline paramete
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run -c fusion.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "v2.5.0" \
+nextflow run -c fusion.config Ferlab-Ste-Justine/Post-processing-Pipeline -r "v2.6.0" \
     -params-file params.json  \
    --input samplesheet.csv \
    --outdir results/dir \
@@ -145,7 +145,7 @@ nextflow pull Ferlab-Ste-Justine/Post-processing-Pipeline
 
 It is a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [Ferlab-Ste-Justine/Post-processing-Pipeline releases page](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/tags) and find the latest pipeline version - numeric only (eg. `2.5.0`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 2.5.0`. Of course, you can switch to another version by changing the number after the `-r` flag.
+First, go to the [Ferlab-Ste-Justine/Post-processing-Pipeline releases page](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/tags) and find the latest pipeline version - numeric only (eg. `v2.6.0`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r v2.6.0`. Of course, you can switch to another version by changing the number after the `-r` flag.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future. For example, at the bottom of the MultiQC reports.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -394,7 +394,7 @@ manifest {
     description     = """Variant analysis for genome and exome GVCFs"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.10.1'
-    version         = '2.5.0'
+    version         = '2.6.0'
     doi             = ''
 }
 


### PR DESCRIPTION

Need to make a new tag as a I need to deploy recent changes in Qlin (allow to skip exomiser for specific families).
Bumping version to v2.6.0

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint --release`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
