### PR TITLE
refactor: BIOINFO-30 replace local snp vqsr recalibration module by n…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### `Added`
+
+- [#66](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/66) Allow to configure the first step of VQSR SNP variant recalibration (model building) via parameters
+
+
 ## v2.6.0 - <small>2025-02-07</small>
 
 ### `Added`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -62,6 +62,22 @@ process {
         ext.args = {filters.collect{ "--filter \"${it.expression}\" --filter-name \"${it.name}\"" }.join(" ")}
     }
 
+    withName: GATK4_VARIANTRECALIBRATOR_SNP {
+        container = 'broadinstitute/gatk:4.5.0.0'
+        ext.prefix = {meta.id + ".snp.vqsr"}
+
+        def tranches = params.vqsr_snp_tranches.collect{"-tranche $it"}.join(' ')
+        def annotationValues = params.vqsr_snp_annotations.collect{"-an $it"}.join(' ')
+        def args_list = [
+            tranches,
+            annotationValues,
+            "--trust-all-polymorphic",
+            "--max-gaussians 6",
+            "--mode SNP"
+        ]
+        ext.args = args_list.join(" ")
+    }
+
     withName: EXOMISER { 
         container = 'ferlabcrsj/exomiser:2.4.1'
         publishDir = new_publish_dir([

--- a/conf/test.config
+++ b/conf/test.config
@@ -43,14 +43,16 @@ params {
     vep_genome = "GRCh38"
 
     // Filters for hard filtering
-    hardFilters = [[name: 'QD2', expression: 'QD < 2.0'],
-		           [name: 'QD1', expression: 'QD < 1.0'],
-                   [name: 'QUAL30', expression: 'QUAL < 30.0'],
-                   [name: 'SOR3', expression: 'SOR > 3.0'],
-                   [name: 'FS60', expression: 'FS > 60.0'],
-                   [name: 'MQ40', expression: 'MQ < 40.0'],
-                   [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
-                   [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']]
+    hardFilters = [
+        [name: 'QD2', expression: 'QD < 2.0'],
+        [name: 'QD1', expression: 'QD < 1.0'],
+        [name: 'QUAL30', expression: 'QUAL < 30.0'],
+        [name: 'SOR3', expression: 'SOR > 3.0'],
+        [name: 'FS60', expression: 'FS > 60.0'],
+        [name: 'MQ40', expression: 'MQ < 40.0'],
+        [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
+        [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']
+    ]
     
     tools = "vep,exomiser"
 

--- a/docs/reference_data.md
+++ b/docs/reference_data.md
@@ -38,6 +38,30 @@ These are all highly validated variance ressources currently required by VQSR.
 
 Extra settings (ex: resource prior probabilities, tranches, etc.) required to run the different VQSR steps are injected through pipeline parameters or hard coded in the vqsr modules. The values chosen for these settings are based on NIH [Biowulf](https://hpc.nih.gov/training/gatk_tutorial/vqsr.html) 
 
+We aim to fully configure VQSR settings in the future and remove any hard-coded values, including reference data files. We are progressively adding configuration parameters for each VQSR process, but this work is not yet complete. If a parameter is not specified, it will default to the previous hard-coded value. To maintain harmonization, it is best NOT to specify the parameter or use a value equivalent to the default. Available configuration parameters involving VQSR reference data files are documented below.
+
+#### vqsr_snp_resources parameter
+
+> **⚠️ Warning: We recommend not setting this parameter for now until all VQSR processes are configurable.**
+
+The `vqsr_snp_resources` parameter is used to specify the reference datasets for Variant Quality Score Recalibration (VQSR) for SNPs. VQSR is a machine learning-based approach that uses known, high-confidence variants to build a model of variant quality. This model is then applied to the variants in your dataset to assign quality scores, which can be used to filter out low-quality variants.
+
+The `vqsr_snp_resources` parameter is a list of dictionaries, each containing the following keys:
+- `labels`: A string specifying the labels for the resource. Refer to the [gatk VariantRecalibrator documentation](https://gatk.broadinstitute.org/hc/en-us/articles/360036510892-VariantRecalibrator#--resource) for a description of the expected format.
+- `vcf`: The path to the VCF file containing the reference variants.
+- `index`: The path to the index file for the VCF file.
+
+Here is an example:
+
+```
+   vqsr_snp_resources = [
+        [labels: "hapmap,known=false,training=true,truth=true,prior=15", vcf: "data-test/reference/broad/hapmap_3.3.hg38.vcf.gz", index: "data-test/reference/broad/hapmap_3.3.hg38.vcf.gz.tbi"],
+        [labels: "omni,known=false,training=true,truth=false,prior=12", vcf: "data-test/reference/broad/1000G_omni2.5.hg38.vcf.gz", index: "data-test/reference/broad/1000G_omni2.5.hg38.vcf.gz.tbi"],
+        [labels: "1000G,known=false,training=true,truth=false,prior=10", vcf: "data-test/reference/broad/1000G_phase1.snps.high_confidence.hg38.vcf.gz", index: "data-test/reference/broad/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi"],
+        [labels: "dbsnp,known=true,training=false,truth=false,prior=7", vcf: "data-test/reference/broad/Homo_sapiens_assembly38.dbsnp138.vcf", index: "data-test/reference/broad/Homo_sapiens_assembly38.dbsnp138.vcf.idx"]
+    ]
+```
+
 ## Interval file 
 The `intervalFile` parameter specifies the path to an interval file (ex: `broad/wgs_calling_regions.hg38.interval_list`).
 

--- a/modules.json
+++ b/modules.json
@@ -40,6 +40,11 @@
             "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
             "installed_by": ["modules"]
           },
+          "gatk4/variantrecalibrator": {
+            "branch": "master",
+            "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+            "installed_by": ["modules"]
+          },
           "tabix/tabix": {
             "branch": "master",
             "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",

--- a/modules/nf-core/gatk4/variantrecalibrator/environment.yml
+++ b/modules/nf-core/gatk4/variantrecalibrator/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/gatk4
+  - bioconda::gatk4=4.6.1.0
+  - bioconda::gcnvkernel=0.9

--- a/modules/nf-core/gatk4/variantrecalibrator/main.nf
+++ b/modules/nf-core/gatk4/variantrecalibrator/main.nf
@@ -1,0 +1,71 @@
+process GATK4_VARIANTRECALIBRATOR {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b2/b28daf5d9bb2f0d129dcad1b7410e0dd8a9b087aaf3ec7ced929b1f57624ad98/data':
+        'community.wave.seqera.io/library/gatk4_gcnvkernel:e48d414933d188cd' }"
+
+    input:
+    tuple val(meta), path(vcf), path(tbi) // input vcf and tbi of variants to recalibrate
+    path resource_vcf   // resource vcf
+    path resource_tbi   // resource tbi
+    val labels          // string (or list of strings) containing dedicated resource labels already formatted with '--resource:' tag
+    path  fasta
+    path  fai
+    path  dict
+
+    output:
+    tuple val(meta), path("*.recal")   , emit: recal
+    tuple val(meta), path("*.idx")     , emit: idx
+    tuple val(meta), path("*.tranches"), emit: tranches
+    tuple val(meta), path("*plots.R")  , emit: plots, optional:true
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference_command = fasta ? "--reference $fasta " : ''
+    def labels_command = labels.join(' ')
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK VariantRecalibrator] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
+    """
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        VariantRecalibrator \\
+        --variant $vcf \\
+        --output ${prefix}.recal \\
+        --tranches-file ${prefix}.tranches \\
+        $reference_command \\
+        --tmp-dir . \\
+        $labels_command \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.recal
+    touch ${prefix}.idx
+    touch ${prefix}.tranches
+    touch ${prefix}plots.R
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/gatk4/variantrecalibrator/meta.yml
+++ b/modules/nf-core/gatk4/variantrecalibrator/meta.yml
@@ -1,0 +1,112 @@
+name: gatk4_variantrecalibrator
+description: |
+  Build a recalibration model to score variant quality for filtering purposes.
+  It is highly recommended to follow GATK best practices when using this module,
+  the gaussian mixture model requires a large number of samples to be used for the
+  tool to produce optimal results. For example, 30 samples for exome data. For more details see
+  https://gatk.broadinstitute.org/hc/en-us/articles/4402736812443-Which-training-sets-arguments-should-I-use-for-running-VQSR-
+keywords:
+  - gatk4
+  - recalibration model
+  - variantrecalibrator
+tools:
+  - gatk4:
+      description: |
+        Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+        with a primary focus on variant discovery and genotyping. Its powerful processing engine
+        and high-performance computing features make it capable of taking on projects of any size.
+      homepage: https://gatk.broadinstitute.org/hc/en-us
+      documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
+      doi: 10.1158/1538-7445.AM2017-3590
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - vcf:
+        type: file
+        description: input vcf file containing the variants to be recalibrated
+        pattern: "*.vcf.gz"
+    - tbi:
+        type: file
+        description: tbi file matching with -vcf
+        pattern: "*.vcf.gz.tbi"
+  - - resource_vcf:
+        type: file
+        description: all resource vcf files that are used with the corresponding '--resource'
+          label
+        pattern: "*.vcf.gz"
+  - - resource_tbi:
+        type: file
+        description: all resource tbi files that are used with the corresponding '--resource'
+          label
+        pattern: "*.vcf.gz.tbi"
+  - - labels:
+        type: string
+        description: necessary arguments for GATK VariantRecalibrator. Specified to
+          directly match the resources provided. More information can be found at
+          https://gatk.broadinstitute.org/hc/en-us/articles/5358906115227-VariantRecalibrator
+  - - fasta:
+        type: file
+        description: The reference fasta file
+        pattern: "*.fasta"
+  - - fai:
+        type: file
+        description: Index of reference fasta file
+        pattern: "fasta.fai"
+  - - dict:
+        type: file
+        description: GATK sequence dictionary
+        pattern: "*.dict"
+output:
+  - recal:
+      - meta:
+          type: file
+          description: Output recal file used by ApplyVQSR
+          pattern: "*.recal"
+      - "*.recal":
+          type: file
+          description: Output recal file used by ApplyVQSR
+          pattern: "*.recal"
+  - idx:
+      - meta:
+          type: file
+          description: Index file for the recal output file
+          pattern: "*.idx"
+      - "*.idx":
+          type: file
+          description: Index file for the recal output file
+          pattern: "*.idx"
+  - tranches:
+      - meta:
+          type: file
+          description: Output tranches file used by ApplyVQSR
+          pattern: "*.tranches"
+      - "*.tranches":
+          type: file
+          description: Output tranches file used by ApplyVQSR
+          pattern: "*.tranches"
+  - plots:
+      - meta:
+          type: file
+          description: Optional output rscript file to aid in visualization of the input
+            data and learned model.
+          pattern: "*plots.R"
+      - "*plots.R":
+          type: file
+          description: Optional output rscript file to aid in visualization of the input
+            data and learned model.
+          pattern: "*plots.R"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@GCJMackenzie"
+  - "@nickhsmith"
+maintainers:
+  - "@GCJMackenzie"
+  - "@nickhsmith"

--- a/modules/nf-core/gatk4/variantrecalibrator/tests/AS.config
+++ b/modules/nf-core/gatk4/variantrecalibrator/tests/AS.config
@@ -1,0 +1,7 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    withName: GATK4_VARIANTRECALIBRATOR {
+        ext.args = '-mode SNP -an QD -an MQ -an FS -AS'
+    }
+}

--- a/modules/nf-core/gatk4/variantrecalibrator/tests/main.nf.test
+++ b/modules/nf-core/gatk4/variantrecalibrator/tests/main.nf.test
@@ -1,0 +1,167 @@
+nextflow_process {
+
+    name "Test Process GATK4_VARIANTRECALIBRATOR"
+    script "../main.nf"
+    process "GATK4_VARIANTRECALIBRATOR"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gatk4"
+    tag "gatk4/variantrecalibrator"
+
+    test("homo sapiens - vcf - allele specificity") {
+        config "./AS.config"
+        when {
+            process {
+                """
+                input_vcf = [ [ id:'test' ], // meta map
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz", checkIfExists: true),
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz.tbi", checkIfExists: true)
+                        ]
+
+                resources_vcf = [
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_phase1.snps.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz", checkIfExists: true)
+                            ]
+                resources_tbi = [
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_phase1.snps.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi", checkIfExists: true)
+                            ]
+                labels = [
+                            '--resource:hapmap,known=false,training=true,truth=true,prior=15.0 hapmap_3.3.hg38.vcf.gz',
+                            '--resource:omni,known=false,training=true,truth=false,prior=12.0 1000G_omni2.5.hg38.vcf.gz',
+                            '--resource:1000G,known=false,training=true,truth=false,prior=10.0 1000G_phase1.snps.hg38.vcf.gz',
+                            '--resource:dbsnp,known=true,training=false,truth=false,prior=2.0 dbsnp_138.hg38.vcf.gz'
+                        ]
+
+                fasta = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.fasta", checkIfExists: true)
+                fai = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai", checkIfExists: true)
+                dict = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.dict", checkIfExists: true)
+
+                input = [input_vcf, resources_vcf, resources_tbi, labels, fasta, fai, dict]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.recal[0][1]).name,
+                    file(process.out.idx[0][1]).name,
+                    process.out.tranches,
+                    process.out.plots,
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo sapiens - vcf - no allele specificity") {
+        config "./noAS.config"
+        when {
+            process {
+                """
+                input_vcf = [ [ id:'test' ], // meta map
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz", checkIfExists: true),
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz.tbi", checkIfExists: true)
+                        ]
+
+                resources_vcf = [
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_phase1.snps.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz", checkIfExists: true)
+                            ]
+                resources_tbi = [
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_phase1.snps.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi", checkIfExists: true)
+                            ]
+                labels = [
+                            '--resource:hapmap,known=false,training=true,truth=true,prior=15.0 hapmap_3.3.hg38.vcf.gz',
+                            '--resource:omni,known=false,training=true,truth=false,prior=12.0 1000G_omni2.5.hg38.vcf.gz',
+                            '--resource:1000G,known=false,training=true,truth=false,prior=10.0 1000G_phase1.snps.hg38.vcf.gz',
+                            '--resource:dbsnp,known=true,training=false,truth=false,prior=2.0 dbsnp_138.hg38.vcf.gz'
+                        ]
+
+                fasta = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.fasta", checkIfExists: true)
+                fai = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai", checkIfExists: true)
+                dict = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.dict", checkIfExists: true)
+
+                input = [input_vcf, resources_vcf, resources_tbi, labels, fasta, fai, dict]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.recal[0][1]).name,
+                    file(process.out.idx[0][1]).name,
+                    process.out.tranches,
+                    process.out.plots,
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo sapiens - vcf - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input_vcf = [ [ id:'test' ], // meta map
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz", checkIfExists: true),
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz.tbi", checkIfExists: true)
+                        ]
+
+                resources_vcf = [
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_phase1.snps.hg38.vcf.gz", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz", checkIfExists: true)
+                            ]
+                resources_tbi = [
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/1000G_phase1.snps.hg38.vcf.gz.tbi", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi", checkIfExists: true)
+                            ]
+                labels = [
+                            '--resource:hapmap,known=false,training=true,truth=true,prior=15.0 hapmap_3.3.hg38.vcf.gz',
+                            '--resource:omni,known=false,training=true,truth=false,prior=12.0 1000G_omni2.5.hg38.vcf.gz',
+                            '--resource:1000G,known=false,training=true,truth=false,prior=10.0 1000G_phase1.snps.hg38.vcf.gz',
+                            '--resource:dbsnp,known=true,training=false,truth=false,prior=2.0 dbsnp_138.hg38.vcf.gz'
+                        ]
+
+                fasta = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.fasta", checkIfExists: true)
+                fai = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai", checkIfExists: true)
+                dict = file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/chr21/sequence/genome.dict", checkIfExists: true)
+
+                input = [input_vcf, resources_vcf, resources_tbi, labels, fasta, fai, dict]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/gatk4/variantrecalibrator/tests/main.nf.test.snap
+++ b/modules/nf-core/gatk4/variantrecalibrator/tests/main.nf.test.snap
@@ -1,0 +1,133 @@
+{
+    "homo sapiens - vcf - allele specificity": {
+        "content": [
+            [
+                "versions.yml:md5,fb9c98d8bd2f8335179f7c037c63bb0d"
+            ],
+            "test.recal",
+            "test.recal.idx",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.tranches:md5,ad52fa69325c758f458a30ee5b43d6b5"
+                ]
+            ],
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.1",
+            "nextflow": "24.10.0"
+        },
+        "timestamp": "2024-11-06T10:19:03.416258473"
+    },
+    "homo sapiens - vcf - no allele specificity": {
+        "content": [
+            [
+                "versions.yml:md5,fb9c98d8bd2f8335179f7c037c63bb0d"
+            ],
+            "test.recal",
+            "test.recal.idx",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.tranches:md5,c029e52fd63a893e1154cc9144a19eeb"
+                ]
+            ],
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.1",
+            "nextflow": "24.10.0"
+        },
+        "timestamp": "2024-11-06T10:26:53.032044124"
+    },
+    "homo sapiens - vcf - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.recal:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.idx:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tranches:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "testplots.R:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,fb9c98d8bd2f8335179f7c037c63bb0d"
+                ],
+                "idx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.idx:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "plots": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "testplots.R:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "recal": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.recal:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tranches": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tranches:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,fb9c98d8bd2f8335179f7c037c63bb0d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.1",
+            "nextflow": "24.10.0"
+        },
+        "timestamp": "2024-11-06T10:14:43.858797367"
+    }
+}

--- a/modules/nf-core/gatk4/variantrecalibrator/tests/noAS.config
+++ b/modules/nf-core/gatk4/variantrecalibrator/tests/noAS.config
@@ -1,0 +1,8 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName: GATK4_VARIANTRECALIBRATOR {
+        ext.args = '-mode SNP -an QD -an MQ -an FS -an SOR'
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,6 +57,10 @@ params {
         [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']
     ]
 
+    // VQSR parameters
+    vqsr_snp_tranches = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0"]
+    vqsr_snp_annotations = ["QD","MQRankSum","ReadPosRankSum","FS","MQ","SOR","DP"]
+    vqsr_snp_resources = null  //We cannot define the default value here, as it depends on the broad parameter. It will be initialized in the VQSR workflow.
 
     allow_old_gatk_data = false
 	

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -51,12 +51,6 @@
           "hidden": true,
           "help_text": "Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`."
         },
-        "broad": {
-          "type": "string",
-          "description": "Directory containing the references for vqsr",
-          "help_text": "Path to the directory containing 4 important files: \\n1. The Hapmap file for vqsr training\\n2. The omni2.5 file for vqsr training\\n3. The 1000G SNP reference file for vqsr training\\n4. The dbsnp database for vqsr training",
-          "format": "directory-path"
-        },
         "intervalsFile": {
           "type": "string",
           "description": "Path to interval file",
@@ -301,6 +295,33 @@
         }
       }
     },
+    "vqsr": {
+      "title": "VQSR",
+      "type": "object",
+      "description": "VQSR parameters",
+      "default": "",
+      "properties": {
+        "broad": {
+          "type": "string",
+          "description": "Directory containing the references for vqsr",
+          "help_text": "Path to the directory containing 4 important files: \\n1. The Hapmap file for vqsr training\\n2. The omni2.5 file for vqsr training\\n3. The 1000G SNP reference file for vqsr training\\n4. The dbsnp database for vqsr training",
+          "format": "directory-path"
+        },
+        "vqsr_snp_resources": {
+          "type": "string",
+          "description": "Specifies reference datasets for VQSR to build a model for filtering SNPs.",
+          "help_text": "Specifies reference datasets for VQSR to build a model for filtering SNPs. Specifies reference datasets for VQSR to filter SNPs. Do not set this parameter yet; it will be automatically configured by the pipeline."
+        },
+        "vqsr_snp_tranches": {
+          "type": "array",
+          "description": "Specifies the tranches to use for VQSR SNP filtering."
+        },
+        "vqsr_snp_annotations": {
+          "type": "array",
+          "description": "Specifies the annotations to use for VQSR SNP filtering."
+        }
+      }
+    },
     "vep": {
       "title": "vep",
       "type": "object",
@@ -324,13 +345,13 @@
           "help text": "Ex: GRCh38"
         },
         "download_cache": {
-            "type": "boolean",
-            "description": "Whether to download the vep cache or not"
+          "type": "boolean",
+          "description": "Whether to download the vep cache or not"
         },
         "outdir_cache": {
-            "type": "string",
-            "description": "Path where vep cache will be downloaded. If not provided, will default to ${outdir}/cache.",
-            "format": "directory-path"
+          "type": "string",
+          "description": "Path where vep cache will be downloaded. If not provided, will default to ${outdir}/cache.",
+          "format": "directory-path"
         }
       },
       "if": {
@@ -497,6 +518,9 @@
     },
     {
       "$ref": "#/definitions/generic_options"
+    },
+    {
+      "$ref": "#/definitions/vqsr"
     },
     {
       "$ref": "#/definitions/vep"

--- a/subworkflows/local/vqsr/main.nf
+++ b/subworkflows/local/vqsr/main.nf
@@ -1,4 +1,10 @@
-include { variantRecalibratorIndel; variantRecalibratorSNP; applyVQSRIndel; applyVQSRSNP} from '../../../modules/local/vqsr'
+include { GATK4_VARIANTRECALIBRATOR as GATK4_VARIANTRECALIBRATOR_SNP} from '../../../modules/nf-core/gatk4/variantrecalibrator/main'
+include { variantRecalibratorIndel; applyVQSRIndel; applyVQSRSNP} from '../../../modules/local/vqsr'
+include { attachMultiqcReport } from '../../nf-core/utils_nfcore_pipeline/main.nf'
+
+def getResourceLabels(resources) {
+    return resources.collect{it -> "--resource:" + it.labels + " ${file(it.vcf).getFileName()}"}
+}
 
 /**
 Filter out probable artifacts from the callset using the Variant Quality Score Recalibration (VQSR) procedure
@@ -10,21 +16,58 @@ All output files will be prefixed with the given prefixId.
 */
 workflow VQSR {
     take:
-        input // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
+        input // channel: (val(meta), [.vcf.gz, .vcf.gz.tbi])
+        referenceGenomeFasta
+        referenceGenomeFai
+        referenceGenomeDict
+
     main:
-        referenceGenome = file(params.referenceGenome)
 
-        //If VQSR is not used (i.e. only whole exome data), we allow to avoid passing the broad paramater.
-        //This code, however, will be executed anyway, so we need to handle this scenario.
-        broad = params.broad? file(params.broad): ""
+        // We need to keep this until we standardize passing reference genome files in all VQSR processes.
+        // We should use referenceGenomeFasta, referenceGenomeFai, and referenceGenomeDict workflow inputs instead.
+        def referenceGenome = file(params.referenceGenome)
+        
+        // Check if the broad resource is provided because it can be omitted if only whole exome data is used.
+        def broad = params.broad? file(params.broad): ""
+ 
+        // Temporarily initializing vqsr_snp_resources to maintain previous behavior that hard-coded these settings. 
+        // We couldn't specify these defaults in the config because the broad parameter is null by default.    
+        def vqsrSnpResources = params.vqsr_snp_resources ?:  [
+            [labels: "hapmap,known=false,training=true,truth=true,prior=15", vcf: "${params.broad}/hapmap_3.3.hg38.vcf.gz", index: "${params.broad}/hapmap_3.3.hg38.vcf.gz.tbi"],
+            [labels: "omni,known=false,training=true,truth=false,prior=12", vcf: "${params.broad}/1000G_omni2.5.hg38.vcf.gz", index: "${params.broad}/1000G_omni2.5.hg38.vcf.gz.tbi"],
+            [labels: "1000G,known=false,training=true,truth=false,prior=10", vcf: "${params.broad}/1000G_phase1.snps.high_confidence.hg38.vcf.gz", index: "${params.broad}/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi"],
+            [labels: "dbsnp,known=true,training=false,truth=false,prior=7", vcf: "${params.broad}/Homo_sapiens_assembly38.dbsnp138.vcf", index: "${params.broad}/Homo_sapiens_assembly38.dbsnp138.vcf.idx"]
+        ]
 
-        outputSNP = variantRecalibratorSNP(input, referenceGenome, broad)
-            | join(input)
+        def ch_versions = Channel.empty()
+        def ch_input = input.map{meta, files -> [meta, files[0], files[1]]}
+
+        // Build the VQSR model for SNP
+        GATK4_VARIANTRECALIBRATOR_SNP( 
+            ch_input,
+            vqsrSnpResources.collect{file(it.vcf)},
+            vqsrSnpResources.collect{file(it.index)},
+            getResourceLabels(vqsrSnpResources),
+            referenceGenomeFasta,
+            referenceGenomeFai,
+            referenceGenomeDict
+        )
+        def outputFromRecalibratorSNP = GATK4_VARIANTRECALIBRATOR_SNP.out.recal
+            .join(GATK4_VARIANTRECALIBRATOR_SNP.out.idx)
+            .map{meta, recal, recalIdx -> [meta, [recal, recalIdx]]}
+            .join(GATK4_VARIANTRECALIBRATOR_SNP.out.tranches)
+        ch_versions = ch_versions.mix(GATK4_VARIANTRECALIBRATOR_SNP.out.versions)
+
+        // Apply the VQSR model for SNP
+        def outputSNP = outputFromRecalibratorSNP.join(input)
             | applyVQSRSNP
-        output = variantRecalibratorIndel(input, referenceGenome, broad)
+
+        // Build and apply VQSR model on INDEL
+        def ch_output = variantRecalibratorIndel(input, referenceGenome, broad)
             | join(outputSNP)
             | applyVQSRIndel
 
     emit:
-        output // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
+        output = ch_output // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
+        versions = ch_versions // channel: [ versions.yml ]
 }

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -39,7 +39,7 @@ def tagArtifacts(ch_artifact_input, hardFilters, pathFasta, pathFai, pathDict) {
     def ch_vqsr_input = ch_artifact_input.filter{it[0].sequencingType == "WGS"}.map{ meta, vcf, tbi -> [meta, [vcf,tbi]]}
     def ch_variantfiltration_input = ch_artifact_input.filter{it[0].sequencingType == "WES"}
 
-    def ch_vqsr_output = VQSR(ch_vqsr_input)
+    def ch_vqsr_output = VQSR(ch_vqsr_input, pathFasta, pathFai, pathDict).output
 
     def ch_gatk4_variantfiltration_output = GATK4_VARIANTFILTRATION(
         ch_variantfiltration_input,


### PR DESCRIPTION
This PR replaces a custom process called variantRecalibratorSNP in our post-processing pipeline with a standard nf-core module.  There should be  no change of behaviour for the end user.

It also makes hard-coded reference data paths and settings configurable via parameters for this specific process. These parameters will be initialized to the same values as the previous hard-coded settings if they are not specified. Since the other VQSR process settings are still hard-coded, it is recommended that users do not change the defaults to ensure all settings remain harmonized. This recommendation has been emphasized in the documentation.

**Local Tests**

We run the pipeline locally using the public test dataset.  We inspect the output for family1, which should pass through VQSR subworkflow.

All output files are present and named as expected ✅ 
 - The VQSR process output is copied in folder results/gatk4, as expected. 
  - We can see the 3 output files associated to family1.  More precisely, we see the recal file, the recal index file and the tranches file.  
  - These files are prefixed with `family1.snp.vqsr` as expected.

We run the pipeline on the main branch and compare the output files with the output files from the current branch. All differences should be harmless, i.e. there should be no consequence on the final output ✅ 
 - The tranches files are identical
 - The recal files content is identical except for the line containing the gatk command according to a `diff` command.
-  For each recal file, we extracted the GATK command and used a sed command to have one option per line. We then re-ran the `diff` command on the obtained files. The differences appear to be harmless and are caused by:     
     - date differences
     - differences in nextflow process work folder path
     - output file prefix name change, which is to be expected
     - path to the fasta reference file is chr22.fa instead  chr22/chr22.fa which is normal because we are now staging only the fasta file instead the whole broad folder
     - extra option `--tmp-dir . ` in the new nf-core process

Compare the process scripts in found in the nextflow process folders.  The gatk commands should be equivalent. ✅ 
- Found only harmless differences:
  - options are not in the same order
  - sometimes long option names are used instead short option names (`--variant` instead of `-V`, `--output` instead of `-O`, `--reference` instead of `-R`)
  - option `--tmp-dir` . specified
  - In the resource list, we see only the filename for the vcf file, which is normal as we don't stage the whole broad folder anymore

Compare the body of the vcf obtained after the normalisation step between the main branch and this branch. They should be identical.  ✅ 

When there is no whole genome data family in the samplesheet, it should be still ok to avoid specifying the broad parameter ✅ 

**Juno tests**

We shall replicate a few tests that we did locally in Juno. 

1) Make sure that the pipeline is run successfully ✅ 
2) Check that the output files are there for family1 (recal, recal index, tranchers) ✅ 
3) Compare recal file content, only difference with main branch should be the line containing the gatk command ✅ 
4) Compare tranche file content, should be identical to main branch ✅ 
5) Inspect the process script ✅ 
6) Check that the body of the vcf obtained after the normalisation step, it should not changed in comparison to the main branch ✅ 

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint --release`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
