### PR TITLE
fix: CLIN-3730 support vcf extension for input gvcf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#66](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/66) Allow to configure the first step of VQSR SNP variant recalibration (model building) via parameters
 
+### `Fixed`
+- [#69](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/69) Accept .vcf and .vcf.gz file extensions for input gvcf files
 
 ## v2.6.0 - <small>2025-02-07</small>
 

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -29,7 +29,7 @@
             "gvcf": {
                 "errorMessage": "Filename must have extension '.gvcf' or contain 'g' and end by 'vcf'",
                 "type": "string",
-                "pattern": "^\\S+\\.g(enome)?(\\.)?vcf(\\.gz)?$",
+                "pattern": "^\\S+\\.(vcf|gvcf)(\\.gz)?$",
                 "format": "file-path",
                 "exists": true
             },


### PR DESCRIPTION
We change the regex used to validate input gvcf files extensions.
It was not matching .vcf or .vcf.gz and this was causing problems in QLIN.

It should now match any file ending with: ".vcf", ".vcf.gz", ".gvcf" or ".gvcf.gz"

**Local Tests**

- Tested running the pipeline locally, using the following file extensions: ✅ 
 ".vcf.gz", ".gvcf.gz", ".g.vcf.gz", ".genome.vcf.gz"
- Idem above, but without the .gz suffix ✅ 

**Juno Test**

Test running the pipeline with the public dataset in JUNO, as usual. ✅ 

<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint --release`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
