### PR TITLE
BIOINFO-56 Allow to re-start from specific steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### `Added`
-- [#76](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/76) Allow to start exomiser from previous ensemblvep results
+- [#76](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/76) Allow to start/re-start pipeline from defined steps. 
   
 ### `Removed`
 - [#75](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/75) Remove the nextflow docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### `Added`
+- [#76](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/76) Allow to start exomiser from previous ensemblvep results
+  
 ### `Removed`
-- [75](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/75) Remove the nextflow docker image
-
+- [#75](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/75) Remove the nextflow docker image
+  
 ## v2.8.1 - 2025-04-11 
 ### `Changed`
-- [#73] Pass intervals file to GenotypeGVCFs if available.
+- [#73](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/73) Pass intervals file to GenotypeGVCFs if available.
 
 ## v2.8.0 - <small>2025-04-03</small>
 

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -26,6 +26,13 @@
                 "default": "WGS",
                 "enum": ["WGS", "WES"]
             },
+            "familyPheno": {
+                "errorMessage": "Filename of the pedigree file, mandatory for exomiser",
+                "meta": ["familyPheno"],
+                "format": "file-path",
+                "pattern": "^\\S+\\.(yml|yaml|json){1}$",
+                "exists": true
+            },
             "gvcf": {
                 "errorMessage": "Filename must have extension '.gvcf' or contain 'g' and end by 'vcf'",
                 "type": "string",
@@ -33,15 +40,25 @@
                 "format": "file-path",
                 "exists": true
             },
-            "familyPheno": {
-                "errorMessage": "Filename of the pedigree file, mandatory for exomiser",
-                "meta": ["familypheno"],
+            "vcf": {
+                "errorMessage": "Filename must have extension '.vcf' or '.vcf.gz",
+                "type": "string",
                 "format": "file-path",
-                "pattern": "^\\S+\\.(yml|yaml|json){1}$",
+                "pattern": "^\\S+\\.vcf(\\.gz)?$",
                 "exists": true
-
+            },
+            "tbi": {
+                "errorMessage": "Filename must have extension '.vcf.tbi' or '.vcf.gz.tbi",
+                "type": "string",
+                "format": "file-path",
+                "pattern": "^\\S+\\.vcf(\\.gz)?.tbi$",
+                "exists": true
             }
+            },
+        "dependentRequired": {
+            "gvcf": ["sample"],
+            "tbi": ["vcf"]
         },
-        "required": ["familyId", "sample", "sequencingType","gvcf"]
+        "required": ["familyId", "sequencingType"]
     }
 }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -55,10 +55,9 @@
                 "exists": true
             }
             },
-        "dependentRequired": {
-            "gvcf": ["sample"],
-            "tbi": ["vcf"]
-        },
-        "required": ["familyId", "sequencingType"]
+        "oneOf": [
+            {"required": ["familyId", "sample", "sequencingType", "gvcf"]},
+            {"required": ["familyId", "sequencingType", "vcf"]}
+        ]
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -129,5 +129,11 @@ process {
 
     withName: 'splitMultiAllelics' {
         container = 'staphb/bcftools:1.20'
+        publishDir = [
+            enabled: params.save_genotyped || params.tools.isBlank(),
+            path: { "${params.outdir}/normalized_genotypes" },
+            publish_mode: params.publish_dir_mode,
+            pattern: '*{splitted.vcf.gz,splitted.vcf.gz.tbi}'
+        ]
     }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -15,20 +15,25 @@ Unless stated otherwise, this document assumes that the default output locations
 The pipeline output is saved step-by-step in the output directory as each step is completed. Below, we provide a description of the output folders corresponding to the main steps, as well as the `pipeline_info` folder, which contains details about the submitted job.
 
 
-- [Directory Structure](#directory-structure)
-- [Pipeline Information: pipeline_info](#pipeline-information-pipeline_info)
-- [Vep Step: ensemblvep](#vep-step-ensemblvep)
-- [Exomiser Step: exomiser/results](#exomiser-step-exomiserresults)
-- [Other Steps](#others-steps)
+- [ferlab/postprocessing: Output](#ferlabpostprocessing-output)
+  - [Introduction](#introduction)
+  - [Overview](#overview)
+  - [Directory Structure](#directory-structure)
+  - [Output](#output)
+  - [Pipeline Information: pipeline\_info](#pipeline-information-pipeline_info)
+  - [VEP Step: ensemblvep](#vep-step-ensemblvep)
+  - [Exomiser Step: exomiser](#exomiser-step-exomiser)
 
 ## Directory Structure
 
-The output directory structure is as follow:
+The output directory structure is as follows:
 
 ```
-|_ pipeline_info/
-|_ ensemblvep/
-|_ exomiser/
+{outdir}
+├── pipeline_info/
+├── csv/
+├── ensemblvep/
+├── exomiser/
 ...
 ```
 
@@ -37,6 +42,17 @@ The `pipeline_info` subdirectory contains details about the pipeline execution a
 The `ensemblvep` subdirectory contains the output after running vep and will appear only if vep is specified in the `tools` parameters.
 
 The `exomiser` subdirectory contains the output after running exomiser and will appear only if exomiser is specified in the `tools` parameters.
+
+The `csv` subdirectory includes index csv files auto-generated for some intermediate steps. They keep the original output channel structure. They are used by the pipeline to further process/re-start from previously generated output.
+
+## Output
+
+By default, **only annotated VCFs (ensemblvep) and Exomiser results are published.**
+
+If needed, you can set the parameter `publish_all` to `true` to publish the outputs from all pipeline steps. These outputs will be saved in subdirectories within the main output directory specified by the `outdir` parameter. The names of the subdirectories will match the nextflow process names.
+
+> [!IMPORTANT]
+> We don't recommend using `publish_all = true` in production. This is primarily useful for testing, debugging or troubleshooting.
 
 ## Pipeline Information: pipeline_info
 
@@ -119,13 +135,7 @@ The family ID should match the family ID in the input sample sheet.
 
 For more details about the content of each of these files, you can have a look at the exomiser documentation [here](https://exomiser.readthedocs.io/en/latest/result_interpretation.html)
 
-Note that, if exomiser is not specified in the `tools` parameter, the exomiser step will not be executed, and the `exomiser` subdirectory will not be created.
+> [!NOTE]
+> If exomiser is not specified in the `tools` parameter, the exomiser step will not be executed, and the `exomiser` subdirectory will not be created.
 
 By default, exomiser output is saved in the `exomiser` subfolder within the main output directory. To save the output to a different location, use the `exomiser_outdir` parameter. In this case, the exomiser files will be written at the root of the specified location.
-
-
-## Others Steps
-
-If needed, you can set the parameter `publish_all` to `true` to publish the outputs from all pipeline steps. These outputs will be saved in subdirectories within the main output directory specified by the `outdir` parameter. The names of the subdirectories will match the nextflow process names.
-
-We don't recommend using this in production. This is primarily useful for testing, debugging or troubleshooting.

--- a/docs/output.md
+++ b/docs/output.md
@@ -32,6 +32,7 @@ The output directory structure is as follows:
 {outdir}
 ├── pipeline_info/
 ├── csv/
+├── normalized_genotypes/
 ├── ensemblvep/
 ├── exomiser/
 ...
@@ -39,17 +40,20 @@ The output directory structure is as follows:
 
 The `pipeline_info` subdirectory contains details about the pipeline execution and metadata relevant to reproducibility, performance optimization and troubleshooting.
 
+The `csv` subdirectory includes auto-generated index csv files for each of the analysis steps included. They keep the original output channel structure. They are used by the pipeline to further process/re-start from previously generated output.
+
+The `normalized_genotypes` subdirectory contains the output after running GATK GenotypeGVCFs and normalizing the variants and will appear if `save_genotyped = true`.
+
 The `ensemblvep` subdirectory contains the output after running vep and will appear only if vep is specified in the `tools` parameters.
 
 The `exomiser` subdirectory contains the output after running exomiser and will appear only if exomiser is specified in the `tools` parameters.
 
-The `csv` subdirectory includes index csv files auto-generated for some intermediate steps. They keep the original output channel structure. They are used by the pipeline to further process/re-start from previously generated output.
 
 ## Output
 
-By default, **only annotated VCFs (ensemblvep) and Exomiser results are published.**
+By default, if vep and/or exomiser are included as tools, **only annotated VCFs (ensemblvep) and Exomiser results are published.** If no tools are included, the final joint-genotyped results are published.
 
-If needed, you can set the parameter `publish_all` to `true` to publish the outputs from all pipeline steps. These outputs will be saved in subdirectories within the main output directory specified by the `outdir` parameter. The names of the subdirectories will match the nextflow process names.
+If needed, you can set `save_genotyped` to `true` to publish the normalized joint-genotyping results or `publish_all` to `true` to publish the outputs from all pipeline steps. These outputs will be saved in subdirectories within the main output directory specified by the `outdir` parameter. The names of the subdirectories will match the nextflow process names.
 
 > [!IMPORTANT]
 > We don't recommend using `publish_all = true` in production. This is primarily useful for testing, debugging or troubleshooting.
@@ -86,7 +90,7 @@ Here we describe in more details the content of the `pipeline_info `subdirectory
 
   The `nextflow.log` file is a copy the nextflow log file.  Note that it will miss logs written after the `workflow.onComplete` handler is run.
 
-## VEP Step: ensemblvep
+## Annotation Step: ensemblvep
 
 The `ensemblvep` subdirectory contains the output of the pipeline after the vep step. 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,6 +19,7 @@ The samplesheet must contains the following columns at the minimum:
 - *sample*: The identifier used for the sample
 - *sequencingType*: Must be either WES (Whole Exome Sequencing) or WGS (Whole Genome Sequencing)
 - *gvcf*: Path to the sample `.gvcf.gz` file
+- *vcf*: Path to the joint-genotyped `vcf.gz` file. **_If starting from vep or exomiser_**
 
 Additionally, there is an optional *familyPheno* column that can contain a `.yml/.json` file providing phenotype information on the family in phenopacket format. This column is only necessary if using the exomiser tool. If exomiser is enabled, it must consistently contain either an empty string or the same phenopacket file for all members of the family. For more details, refer to the exomiser tool section below.
 
@@ -73,13 +74,25 @@ If you wish to repeatedly use the same parameters for multiple runs, rather than
 > [!WARNING]  
 > Do not use `-c <file>` to specify parameters as this will result in errors. Custom config files specified with `-c` must only be used for [tuning process resource specifications](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources), other infrastructural tweaks (such as output directories), or module arguments (args).
 
-#### Starting with Exomiser `--step 'exomiser'`
+### Starting with vep anotation (`--step 'annotation'`) or Exomiser (`--step 'exomiser'`)
+To start from either the annotation step or from exomiser, the csv samplesheet must contain the columns `familyId`, `sequencingType`, and `vcf`, with the optional `tbi`. To start from exomiser, the column `familyPheno` is required.
 
-Exomiser can be run from valid annotated VCF files previously produced by the pipeline. Currently this feature only supports starting from ensemblvep `--exomiser_start_from_vep true`. 
+**sample.csv**
+```csv
+**familyId**,**sequencingType**,**vcf**,**tbi**,**familyPheno**
+CONGE-XXX,WES,CONGE-XXX.snv.vep.vcf.gz,CONGE-XXX.snv.vep.vcf.gz.tbi,CONGE-XXX.pheno.yml
+CONGE-YYY,WES,CONGE-YYY.normalized.vcf.gz,CONGE-YYY.normalized.vcf.gz.tbi,CONGE-YYY.pheno.yml
+```
 
-This option depends on the [output directory structure](output.md#directory-structure) being respected as it looks at the `csv` directory to retrieve the paths to the data.
+#### **This feauture supports using results from a previous run as input.** 
+Both annotation and exomiser can be started from previously generated joint-genotyped VCFs. Optionally, exomiser can be started from previous results of ensemblvep.
 
-See [Exomiser tool](#exomiser-tool) for details on required input.
+If in a previous run `save_genotyped = true` and/or vep was run, the CSV files will be stored under `$outdir/csv/normalized_genotypes.csv` and `$outdir/csv/ensemblvep.csv`.
+
+If the required CSV is found in the same output directory, it will automatically be used as an input when specifying the parameter `allow_intermediate input = true`. This option depends on the [output directory structure](output.md#directory-structure) being respected as it looks at the `csv` directory to retrieve the paths to the data. If output directory is different, the csv will need to be passed manually.
+
+
+See [tools](#tools) for details on required input for each step.
 
 ### Output Customization
 
@@ -122,7 +135,7 @@ This can greatly assist in the identification of potential disease-causing varia
 To run exomiser, activate it via the `tools` parameter (see section above). 
 
 Additionally, provide the exomiser phenopacket file in the samplesheet for each family member in the familyPheno column. If the phenopacket file is not specified for a family, exomiser will be skipped for that family.
-
+`
 Note that the value for the familyPheno column must always be identical for the same family.
 
 #### Exomiser input data
@@ -222,6 +235,8 @@ Parameters summary
 | `intervalsFile` | _Optional_ | Path to the file containg the genome intervals list on which to operate |
 | `tools` | _Optional_ | Additional tools to run separated by commas. Supported tools are `vep` and `exomiser` |
 | `step` | _Optional_ | Step from which to restart the pipeline. Options: `genotype`(default),`annotation`,`exomiser` |
+| `allow_intermediate_input` | _Optional_ | When starting from subsequent steps, use intermediate csv as input samplesheet if found. (default `true`) |
+| `save_genotyped` | _Optional_ | If true, save joint-genotyping results |
 | `vep_cache` | _Optional_ | Path to the vep cache data directory |
 | `vep_cache_version` | _Optional_ | Version of the vep cache. e.g. `111` |
 | `vep_genome` | _Optional_ | Genome assembly version of the vep cache  |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,9 +70,16 @@ work                # Directory containing the nextflow working files
 
 If you wish to repeatedly use the same parameters for multiple runs, rather than specifying each flag in the command, you can specify these in a params file (json or yaml).
 
-> <b>WARNING</b>:  
-Do not use `-c <file>` to specify parameters as this will result in errors. Custom config files specified with `-c` must only be used for [tuning process resource specifications](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources), other infrastructural tweaks (such as output directories), or module arguments (args).
+> [!WARNING]  
+> Do not use `-c <file>` to specify parameters as this will result in errors. Custom config files specified with `-c` must only be used for [tuning process resource specifications](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources), other infrastructural tweaks (such as output directories), or module arguments (args).
 
+#### Starting with Exomiser `--step 'exomiser'`
+
+Exomiser can be run from valid annotated VCF files previously produced by the pipeline. Currently this feature only supports starting from ensemblvep `--exomiser_start_from_vep true`. 
+
+This option depends on the [output directory structure](output.md#directory-structure) being respected as it looks at the `csv` directory to retrieve the paths to the data.
+
+See [Exomiser tool](#exomiser-tool) for details on required input.
 
 ### Output Customization
 
@@ -214,6 +221,7 @@ Parameters summary
 | `broad` | _Optional_ | Path to the directory containing Broad reference data (for VQSR) |
 | `intervalsFile` | _Optional_ | Path to the file containg the genome intervals list on which to operate |
 | `tools` | _Optional_ | Additional tools to run separated by commas. Supported tools are `vep` and `exomiser` |
+| `step` | _Optional_ | Step from which to restart the pipeline. Options: `genotype`(default),`annotation`,`exomiser` |
 | `vep_cache` | _Optional_ | Path to the vep cache data directory |
 | `vep_cache_version` | _Optional_ | Version of the vep cache. e.g. `111` |
 | `vep_genome` | _Optional_ | Genome assembly version of the vep cache  |

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,7 @@ params {
     dbsnpFile = null
     dbsnpFileIndex = null
     tools = ""
+    step = "genotype" // options [genotype (default), annotate, exomiser]
     vep_cache = null
     vep_cache_version = null
     vep_genome = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,12 +48,12 @@ params {
     exclude_mnps    = true
 
     // Output options
-	save_genotyped 	= false
-	vep_outdir		= null
-	outdir_cache	= null
-	exomiser_outdir	= null
+    save_genotyped  = false
+    vep_outdir      = null
+    outdir_cache    = null
+    exomiser_outdir = null
 
-	//Process-specific parameters
+    //Process-specific parameters
     TSfilterSNP = '99'
     TSfilterINDEL = '99'
     hardFilters = [

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,9 @@ params {
     // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input                      = null
+    step                       = 'genotype'
+    allow_intermediate_input   = true
+
     // References
     genome                     = null
     igenomes_base              = 's3://ngi-igenomes/igenomes/'
@@ -22,14 +25,9 @@ params {
     intervalsFile = null
     dbsnpFile = null
     dbsnpFileIndex = null
-    tools = ""
-    step = "genotype" // options [genotype (default), annotate, exomiser]
     vep_cache = null
     vep_cache_version = null
     vep_genome = null
-    vep_outdir = null
-    download_cache = false
-    outdir_cache     = null
     exomiser_genome  = null
     exomiser_data_dir = null
     exomiser_data_version = null
@@ -43,10 +41,19 @@ params {
     exomiser_local_frequency_path = null
     exomiser_local_frequency_index_path = null
     exomiser_start_from_vep = false
-    exomiser_outdir = null
+
+    // Execution options
+    tools           = ""
+    download_cache  = false
+    exclude_mnps    = true
+
+    // Output options
+	save_genotyped 	= false
+	vep_outdir		= null
+	outdir_cache	= null
+	exomiser_outdir	= null
 
 	//Process-specific parameters
-    exclude_mnps = true
     TSfilterSNP = '99'
     TSfilterINDEL = '99'
     hardFilters = [

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -298,7 +298,7 @@
           "description": "Step from which to start the pipeline",
           "enum": [
             "genotype",
-            "annotate",
+            "annotation",
             "exomiser"
           ],
           "default": "genotype",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -292,6 +292,17 @@
           "description": "If true (default), remove lines from input gvcf files that cause compatibility issues with specific pipeline steps.",
           "help_text": "If true (default), Remove lines from input gvcf files that cause compatibility issues with specific pipeline steps. See usage documentation for more details.",
           "default": true
+        },
+        "step" : {
+          "type": "string",
+          "description": "Step from which to start the pipeline",
+          "enum": [
+            "genotype",
+            "annotate",
+            "exomiser"
+          ],
+          "default": "genotype",
+          "help_text": "Step to run. If not specified, pipeline will start from first step: genotype. If specified, pipeline will start from that step."
         }
       }
     },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -28,6 +28,11 @@
           "format": "directory-path",
           "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
           "fa_icon": "fas fa-folder-open"
+        },
+        "allow_intermediate_input": {
+          "type": "boolean",
+          "description": "When re-starting from a subsequent step, allow the pipeline to use intermediate CSV files as input samplesheet when available.",
+          "default": true
         }
       }
     },
@@ -303,6 +308,12 @@
           ],
           "default": "genotype",
           "help_text": "Step to run. If not specified, pipeline will start from first step: genotype. If specified, pipeline will start from that step."
+        },
+        "save_genotyped": {
+          "type": "boolean",
+          "description": "If true, publish the genotyped and normalized vcf files to the output directory.",
+          "help_text": "If true, save the normalized genotyped vcf files to the output directory. If false, only the final vcf files will be saved. Default when no tools are specified",
+          "default": false
         }
       }
     },

--- a/subworkflows/local/channel_create_csv/main.nf
+++ b/subworkflows/local/channel_create_csv/main.nf
@@ -26,13 +26,14 @@ workflow CHANNEL_CREATE_CSV {
 		.collectFile(keepHeader: true, skip: 1, sort: true, storeDir: "${outdir}/csv") { meta, files -> 
 			def column_names = meta.keySet().sort()
 			def column_values = column_names.collect{ key -> meta[key] }
+			def header = column_names.join(",") // create header from the keys of the meta map
 			// generate output directory path for each file in files, check if they exist
 			def files_path = files.collect { outfile ->
 								def filetype = outfile.name.replaceAll(/\.gz$/, '').tokenize('.')[-1]
 								header += ",${filetype}" // get type of file and add to header
 								return "${dir}/${outfile.name}" // return the final ouput path of the file
 							}.join(",") // if multiple files, join the paths with a comma
-			["${tool}.csv", "${column_names.join(",")}\n${column_values.join(",")},${files_path}\n"]
+			["${tool}.csv", "${header}\n${column_values.join(",")},${files_path}\n"]
 	}
 
 }

--- a/subworkflows/local/channel_create_csv/main.nf
+++ b/subworkflows/local/channel_create_csv/main.nf
@@ -1,36 +1,37 @@
 /**
-CHANNEL CREATE CSV
-    This subworkflow creates a CSV file from the input channel. 
-    The CSV file contains the header and the paths of the files.
+WORKFLOW CREATE CSV
+	This subworkflow creates a CSV file from the input channel. 
+	The CSV file contains the header and the paths of the files.
 */
 
 workflow CHANNEL_CREATE_CSV {
 
-    take:
-    ch_input // channel: [ val(meta), [ bam, bai] ]
-    tool    // val(tool) - tool name, must match the name of the tool's output dir
-    outdir  // params.outdir - output directory
+	take:
+	ch_input // channel: [ val(meta), [ bam, bai] ]
+	tool // string: name of the step
+	outdir  // params.outdir - output directory
+	tool_outdir // Optional - Directory for the tool's output files. Must match the tool's output directory. If not provided, the default is the outdir/tool.
 
-    main:
+	main:
 
-    def dir = "${outdir}/${tool}"
+	def dir = tool_outdir ?: "${outdir}/${tool}" // set the output directory of the results
 
-    ch_input.map { channel -> 
-        def meta = channel[0].collectEntries { k, v ->
-                    [ k, v instanceof Path ? v.toUriString() : v]
-                }  // to not loose the complete path when there are meta fields that are files. 
-        def files = channel[1..-1]
-        [meta, files]
-        }
-        .collectFile(keepHeader: true, skip: 1, sort: true, storeDir: "${outdir}/csv") { meta, files -> 
-        def header = meta.keySet().join(",")
-        // generate output directory path for each file in files, check if they exist
-        def files_path = files.collect { outfile ->
-                            def filetype = outfile.name.replaceAll(/\.gz$/, '').tokenize('.')[-1]
-                            header += ",${filetype}" // get type of file and add to header
-                            return "${dir}/${outfile.name}" // return the final ouput path of the file
-                        }.join(",") // if multiple files, join the paths with a comma
-        ["${tool}.csv", "${header}\n${meta.values().join(",")},${files_path}\n"]
-    }
+	ch_input.map { channel -> 
+		def meta = channel[0].collectEntries { k, v ->
+					[ k, v instanceof Path ? v.toUriString() : v] }  // to not loose the complete path when there are meta fields that are files. 
+		def files = channel[1..-1]
+		[meta, files] 
+		}
+		// collect the channel to a CSV file
+		.collectFile(keepHeader: true, skip: 1, sort: true, storeDir: "${outdir}/csv") { meta, files -> 
+			def header = meta.keySet().join(",")
+			// generate output directory path for each file in files, check if they exist
+			def files_path = files.collect { outfile ->
+								def filetype = outfile.name.replaceAll(/\.gz$/, '').tokenize('.')[-1]
+								header += ",${filetype}" // get type of file and add to header
+								return "${dir}/${outfile.name}" // return the final ouput path of the file
+							}.join(",") // if multiple files, join the paths with a comma
+			["${tool}.csv", "${header}\n${meta.values().join(",")},${files_path}\n"]
+	}
 
 }

--- a/subworkflows/local/channel_create_csv/main.nf
+++ b/subworkflows/local/channel_create_csv/main.nf
@@ -1,0 +1,34 @@
+/**
+CHANNEL CREATE CSV
+    This subworkflow creates a CSV file from the input channel. 
+    The CSV file contains the header and the paths of the files.
+*/
+
+workflow CHANNEL_CREATE_CSV {
+
+    take:
+    ch_input // channel: [ val(meta), [ bam, bai] ]
+    tool    // val(tool) - tool name, must match the name of the tool's output dir
+    outdir  // params.outdir - output directory
+
+    main:
+
+    def dir = "${outdir}/${tool}"
+
+    ch_input.map { channel -> 
+        def meta = channel[0]
+        def files = channel[1..-1]
+        [meta, files]
+        }
+        .collectFile(keepHeader: true, skip: 1, sort: true, storeDir: "${outdir}/csv") { meta, files -> 
+        def header = meta.keySet().join(",")
+        // generate output directory path for each file in files, check if they exist
+        def files_path = files.collect { outfile ->
+                            def filetype = outfile.name.replaceAll(/\.gz$/, '').tokenize('.')[-1]
+                            header += ",${filetype}" // get type of file and add to header
+                            return "${dir}/${outfile.name}" // return the final ouput path of the file
+                        }.join(",") // if multiple files, join the paths with a comma
+        ["${tool}.csv", "${header}\n${meta.values().join(",")},${files_path}\n"]
+    }
+
+}

--- a/subworkflows/local/channel_create_csv/main.nf
+++ b/subworkflows/local/channel_create_csv/main.nf
@@ -16,7 +16,9 @@ workflow CHANNEL_CREATE_CSV {
     def dir = "${outdir}/${tool}"
 
     ch_input.map { channel -> 
-        def meta = channel[0]
+        def meta = channel[0].collectEntries { k, v ->
+                    [ k, v instanceof Path ? v.toUriString() : v]
+                }  // to not loose the complete path when there are meta fields that are files. 
         def files = channel[1..-1]
         [meta, files]
         }

--- a/subworkflows/local/channel_create_csv/main.nf
+++ b/subworkflows/local/channel_create_csv/main.nf
@@ -24,14 +24,15 @@ workflow CHANNEL_CREATE_CSV {
 		}
 		// collect the channel to a CSV file
 		.collectFile(keepHeader: true, skip: 1, sort: true, storeDir: "${outdir}/csv") { meta, files -> 
-			def header = meta.keySet().join(",")
+			def column_names = meta.keySet().sort()
+			def column_values = column_names.collect{ key -> meta[key] }
 			// generate output directory path for each file in files, check if they exist
 			def files_path = files.collect { outfile ->
 								def filetype = outfile.name.replaceAll(/\.gz$/, '').tokenize('.')[-1]
 								header += ",${filetype}" // get type of file and add to header
 								return "${dir}/${outfile.name}" // return the final ouput path of the file
 							}.join(",") // if multiple files, join the paths with a comma
-			["${tool}.csv", "${header}\n${meta.values().join(",")},${files_path}\n"]
+			["${tool}.csv", "${column_names.join(",")}\n${column_values.join(",")},${files_path}\n"]
 	}
 
 }

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -76,7 +76,7 @@ workflow PIPELINE_INITIALISATION {
     //
     validateInputParameters()
 
-        //_________Local___________
+    //_________Local___________
     //
     // Create channel from input file provided through params.input
     //
@@ -103,6 +103,11 @@ workflow PIPELINE_INITIALISATION {
                     metasfile[1]                       //file
                 ]
         }.set {ch_samplesheet}
+
+    //
+    // Channel.fromPath()
+    //         .splitCsv(header: true)
+
     emit:
     samplesheet = ch_samplesheet
     versions    = ch_versions
@@ -191,6 +196,21 @@ def validatePhenopacketFiles(family_id, metafiles) {
     }
 }
 
+def findIntermediateInput(step, outdir, start_from_vep) {
+    switch (step) {
+        case "genotype": //TODO
+            return "${outdir}/gatk4_genotypegvcfs/${params.genome}/intermediate_input"
+        case "annotation":
+            log.warn("Using file ${outdir}/csv/genotyped.csv as input for annotation step.")
+            return file("${outdir}/csv/genotyped.csv",checkIfExists: true)
+        case "exomiser":
+            start_from_vep ? log.warn("Using file ${outdir}/csv/annotated.csv as input for exomiser step.") : log.warn("Using file ${outdir}/csv/genotyped.csv as input for exomiser step.")
+            return start_from_vep ? file("${outdir}/csv/annotated.csv",checkIfExists: true) : file("${outdir}/csv/genotyped.csv",checkIfExists: true)
+        default:
+            error("Unknown step: ${step}")
+    }
+
+}
 //_____________Template functions_____________
 //
 // Check and validate pipeline parameters

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/tests/main.function.validatePhenopacketFiles.nf.test
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/tests/main.function.validatePhenopacketFiles.nf.test
@@ -6,7 +6,7 @@ nextflow_function {
 
     function "validatePhenopacketFiles"
 
-    test("Test Function validatePhenopacketFiles with familypheno meta missing for all family members") {
+    test("Test Function validatePhenopacketFiles with familyPheno meta missing for all family members") {
         when {
             function {
                 //The validation should succeed
@@ -27,16 +27,16 @@ nextflow_function {
         }
     }
 
-    test("Test Function validatePhenopacketFiles with familypheno meta empty for all family members") {
+    test("Test Function validatePhenopacketFiles with familyPheno meta empty for all family members") {
         when {
             function {
                 //The validation should succeed
                 """
                 input[0] = "family2"
                 input[1] = [
-                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familypheno: ""], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familypheno: ""], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07056", familyId:"family2", sequencingType:"WES", familypheno: ""], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
+                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familyPheno: ""], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familyPheno: ""], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07056", familyId:"family2", sequencingType:"WES", familyPheno: ""], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
                 ]
                 """
             }
@@ -48,16 +48,16 @@ nextflow_function {
         }
     }
 
-    test("Test Function validatePhenopacketFiles with familypheno meta specified and identical for all family members") {
+    test("Test Function validatePhenopacketFiles with familyPheno meta specified and identical for all family members") {
         when {
             function {
                 //The validation should succeed
                 """
                 input[0] = "family2"
                 input[1] = [
-                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07056", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
+                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07056", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
                 ]
                 """
             }
@@ -69,15 +69,15 @@ nextflow_function {
         }
     }
 
-    test("Test Function validatePhenopacketFiles with familypheno meta not always specified") {
+    test("Test Function validatePhenopacketFiles with familyPheno meta not always specified") {
         when {
             function {
-                //The validation should fail as we expect familypheno to be the same for all family members
+                //The validation should fail as we expect familyPheno to be the same for all family members
                 """
                 input[0] = "family2"
                 input[1] = [
-                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
                     [[sample:"NA07056", familyId:"family2", sequencingType:"WES"], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
                 ]
                 """
@@ -90,16 +90,16 @@ nextflow_function {
         }
     }
 
-    test("Test Function validatePhenopacketFiles with familypheno meta specified but different") {
+    test("Test Function validatePhenopacketFiles with familyPheno meta specified but different") {
         when {
             function {
-                //The validation should fail as we expect familypheno to be the same for all family members
+                //The validation should fail as we expect familyPheno to be the same for all family members
                 """
                 input[0] = "family2"
                 input[1] = [
-                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
-                    [[sample:"NA07056", familyId:"family2", sequencingType:"WES", familypheno: "data-test/pheno/family1.yml"], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
+                    [[sample:"NA07019", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07019.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07022", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family2.yml"], "data-test/gvcf/NA07022.chr22_50000000-51000000.g.vcf.gz"],
+                    [[sample:"NA07056", familyId:"family2", sequencingType:"WES", familyPheno: "data-test/pheno/family1.yml"], "data-test/gvcf/NA07056.chr22_50000000-51000000.g.vcf.gz"]
                 ]
                 """
             }

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -69,12 +69,12 @@ def exomiser(inputChannel,
     cadd_indel_filename
     ) {
     def ch_input_for_exomiser = inputChannel
-        .filter{ meta, vcf, tbi -> meta.familypheno} //only run exomiser on families for which a phenopacket file is specified
+        .filter{ meta, vcf, tbi -> meta.familyPheno} //only run exomiser on families for which a phenopacket file is specified
         .map{meta, vcf, tbi -> [
             meta,
             vcf,
             tbi,
-            meta.familypheno, 
+            meta.familyPheno, 
             meta.sequencingType == "WES"? file(analysis_wes_path) : file(analysis_wgs_path)
         ]}
     def remm_input = ["", ""]
@@ -277,7 +277,8 @@ workflow POSTPROCESSING {
         else {
             ch_exomiser_input = params.step == 'exomiser' ? ch_samplesheet : ch_output_from_splitMultiAllelics
         }
-        
+
+
         exomiser(
             ch_exomiser_input,
             params.exomiser_genome,


### PR DESCRIPTION
## Description

PR introduces the option to start the Exomiser analysis from previously generated data and sets the backbone to implement the option to start from certain steps either from a custom Samplesheet or from data already present in the output directory. 
For now, I implemented the separation of the pipeline in 3 main steps: Genotype (cleaning + joint-genotyping), Annotation (VEP), and Exomiser. 

* Introduces the param `step` with possible values `genotype`[default], `annotation`, and `exomiser`. 
* New workflow `CHANNEL_CREATE_CSV`: this workflow creates a csv from an output channel, including the metadata and constructs the output paths of the resulting files. 
   * Takes any channel, output dir and the process/step name as input. Output path of results is constructed as `{outdir}/{step}/` by default.
   * Step name must match the output subdirectory structure of the publish directive i.e. a step name `ensemblvep` will create a path --> `results/ensemblvep/variants.family1.vcf.gz`. 
   * It preserves the metaMap and channel structure as is. 
   * **Update** --> will take into consideration vep and exomiser output dirs.
* CSV index files are to be created automatically at each step of the pipeline from which we want to re/start from. Currently it is only implemented for VEP. When `--step exomiser --exomiser_start_from_vep true` the pipeline looks for the csv file in the outdir and parses it as input.  **Update**: Implemented the start at annotation and exomiser from the intermediate joint-genotype output.
* Added the params validation. If steps are exomiser or annotation, it will default to running the tools even if not stated explicitly in `--tools`.
* **Update** Added parameter `save_genotyped`. If true, this saves the splitMultiallelics output (last step of the joint-genotyping). Defaults to true when no tools are provided.
* **Update** Added parameter `allow_intermediate_inputs` which will turn on or off the ability to automatically retrieve the csvs.
* **Update** Now we can start from annotation or exomiser using a samplesheet.

> **Note**
> ** Update** Use of samplesheet implemented. --- Some of the changes in this PR do not necessarily affect the introduced feature (like the change in the input_schema) but are setting up the backbone for the subsequent features (like starting from step exomiser with a custom samplesheet instead of the csv).

## Tests

### Local tests
* Checked different combinations of parameters. Tested in the VM running Nextflow 24.04. `-profile test,docker` and `-profile debug,test,docker`
  *  Default -> :white_check_mark: all good, csv got generated
  * `--tools vep` with default step (genotype) -> :white_check_mark: good. annotation.csv created. followed by `--step exomiser --tools vep,exomiser --exomiser_start_from_vep true` -> :white_check_mark: successfully read annotation.csv and started pipeline from exomiser
  * `--step exomiser` without having run the pipeline before, --> :white_check_mark: Error: annotation.csv does not exist. 
  * `--step annotation`  -> :white_check_mark: Error: not yet supported 

### Cqdg-prod, Juno tests
* Run in Nextflow 23 with Juno-test dataset 
* Had to do a couple of changes to the create_csv workflow in order to collect the s3 paths. 
  * Default params --> :white_check_mark: All good, pipeline runs successfully, csv gets created
  * `--step exomiser --exomiser_start_from_vep true` :white_check_mark: All good
   
<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint --release`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
