### PR TITLE
fix: BIOINFO-139 Throw error if exomiser data dir does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 - [#82](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/82) Updated CODEOWNERS to add new maintainers.
 
+### `Fixed`
+- [#83](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/83) Throw error if exomiser data directory does not exist or is empty.
+
 ## v2.10.0 - 2026-01-08
 
 ### `Added`

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -443,7 +443,8 @@
         "exomiser_data_dir": {
           "type": "string",
           "format": "directory-path",
-          "description": "Path to the  exomiser data directory"
+          "description": "Path to the  exomiser data directory",
+          "exists": true
         },
         "exomiser_data_version": {
           "type": "string",

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -276,6 +276,9 @@ def validateInputParameters() {
         validateVepCacheVersion()
     }
     
+    if (isExomiserToolIncluded() || (params.step == 'exomiser')) {
+       file(params.exomiser_data_dir).listFiles().size() > 0 ?: error("ERROR ~ The specified Exomiser data directory '${params.exomiser_data_dir}' is empty. Please provide a valid Exomiser data directory with the required data files.")
+    }
     if (params.allow_old_gatk_data) {
         log.warn "The 'allow_old_gatk_data' parameter is set to true, allowing the pipeline to run with older GATK data in GATK4_GENOTYPEGVCFS. Not recommended for production."
     }


### PR DESCRIPTION
<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

Checks that exomiser dir exists and that it is not empty. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint --release`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
