### PR TITLE
fix: BIOINFO-163 remove isBlank when param can be null

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -179,7 +179,7 @@ process {
     withName: 'splitMultiAllelics' {
         container = 'staphb/bcftools:1.20'
         publishDir = [
-            enabled: params.save_genotyped || params.tools.isBlank(),
+            enabled: params.save_genotyped || !params.tools,
             path: { "${params.outdir}/normalized_genotypes" },
             publish_mode: params.publish_dir_mode,
             pattern: '*{splitted.vcf.gz,splitted.vcf.gz.tbi}'

--- a/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_postprocessing_pipeline/main.nf
@@ -305,7 +305,7 @@ def validateInputParameters() {
     if (params.step == 'annotation' && !isVepToolIncluded()) {
         log.warn "Step is annotation but Ensembl VEP is not included in tools. Running VEP for annotation by default."
     }
-    if ( params.step in ['genotype','normalize'] && (params.tools.isBlank() && !params.save_genotyped ) ){
+    if ( params.step in ['genotype','normalize'] && (!params.tools && !params.save_genotyped ) ){
         log.warn "No tools provided. Publishing genotyped results by default."
     }
     if (params.step == 'inheritance' && !isToolIncluded('slivar')) {

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -244,7 +244,7 @@ workflow POSTPROCESSING {
         //normalize variants
         ch_output_from_splitMultiAllelics = splitMultiAllelics(vcf_for_norm, referenceGenome)
 
-        if (params.save_genotyped || params.tools.isBlank()) {
+        if (params.save_genotyped || !params.tools) {
             //create a csv file with the sample information
             CHANNEL_CREATE_CSV_GENOTYPE(ch_output_from_splitMultiAllelics, "normalized_genotypes", params.outdir, [])
         }


### PR DESCRIPTION
<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

Small change to avoid calling `isBlank` on a param that can be null.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint --release`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
