### PR TITLE
Feat: BIOINFO-184 refactor main pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#94](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/94) Refactor syntax for VQSR modules and subworkflow.
 - [#96](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/96) Refactor syntax for split multi-allelics module.
 - [#97](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/97) Refactor syntax for exclude MNPs workflow.
+- [#98](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline/pull/98) Refactor syntax of main pipeline; helper functions that called processes have been inlined; software versions are now aggregated and written to `pipeline_info/Post-Processing-Pipeline_software_mqc_versions.yml`.
+- `exomiser_local_frequency_index_path` is now optional; when omitted, the index path is derived from `exomiser_local_frequency_path` by appending `.tbi`.
 
 ## [v2.11.0 - 2026-03-18]
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -68,7 +68,6 @@ params {
     exomiser_analysis_wes = "${projectDir}/assets/exomiser/test_exomiser_analysis.yml"
     exomiser_analysis_wgs = "${projectDir}/assets/exomiser/test_exomiser_analysis.yml"
     exomiser_local_frequency_path = "${projectDir}/assets/exomiser/local/local_frequency_test_hg38.tsv.gz"
-    exomiser_local_frequency_index_path = "${projectDir}/assets/exomiser/local/local_frequency_test_hg38.tsv.gz.tbi"
     exomiser_start_from_vep = true
 
     // slivar

--- a/docs/output.md
+++ b/docs/output.md
@@ -70,12 +70,13 @@ Here we describe in more details the content of the `pipeline_info `subdirectory
 |_ pipeline_info
    |_ configs
       |_ nextflow.config
-          ... 
+          ...
    |_ execution_report_2024-12-09_12-03-20.html
    |_ execution_timeline_2024-12-09_12-03-20.html
    |_ execution_trace_2024-12-09_12-03-20.txt
    |_ params_2024-12-09_12-03-23.json
    |_ pipeline_dag_2024-12-09_12-03-20.html
+   |_ Post-Processing-Pipeline_software_mqc_versions.yml
    |_ metadata.txt
    |_ nextflow.log
 ```
@@ -89,6 +90,8 @@ Here we describe in more details the content of the `pipeline_info `subdirectory
   The file prefixed by `params` contains the parameters used by the pipeline.
 
   The file prefixed by `pipeline_dag` contains a diagram of the pipeline steps.
+
+  The `Post-Processing-Pipeline_software_mqc_versions.yml` file aggregates the software versions reported by every module/subworkflow that exposes a `versions` channel (bcftools, GATK4 sub-tools, VEP, exomiser, etc.) plus the pipeline and Nextflow versions. The format is MultiQC-friendly so it can be picked up by an external MultiQC step if/when one is wired in.
 
   The `metadata.txt` file contains various information relevant for reproducibility, such as the original command line, the name of the branch / revision used, the username associated to the command, a list of configuration files passed, the nextflow work directory, etc.
 

--- a/docs/reference_data.md
+++ b/docs/reference_data.md
@@ -27,40 +27,50 @@ for its contributions to genomics and biomedical research.
 
 Files can be downloaded using this link: [GATK Ressource Bundle](https://console.cloud.google.com/storage/browser/genomics-public-data/resources/broad/hg38/v0/)
 
-The broad directory must contain the following files:
-  - HapMap file : hapmap_3.3.hg38.vcf.gz
-  - 1000G omni2.5 file : 1000G_omni2.5.hg38.vcf.gz
-  - 1000G reference file : 1000G_phase1.snps.high_confidence.hg38.vcf.gz
-  - SNP database : Homo_sapiens_assembly38.dbsnp138.vcf.gz
+By default the broad directory is expected to contain the following files (each with its tabix `.tbi` index, except dbsnp which ships with `.idx`):
 
-These are all highly validated variance ressources currently required by VQSR. 
-***The file names are not configurable and are currently hard coded in the pipeline***.
+SNP recalibration:
+  - HapMap : `hapmap_3.3.hg38.vcf.gz` (+ `.tbi`)
+  - 1000G omni2.5 : `1000G_omni2.5.hg38.vcf.gz` (+ `.tbi`)
+  - 1000G high-confidence SNPs : `1000G_phase1.snps.high_confidence.hg38.vcf.gz` (+ `.tbi`)
+  - dbSNP : `Homo_sapiens_assembly38.dbsnp138.vcf` (+ `.idx`)
 
-Extra settings (ex: resource prior probabilities, tranches, etc.) required to run the different VQSR steps are injected through pipeline parameters or hard coded in the vqsr modules. The values chosen for these settings are based on NIH [Biowulf](https://hpc.nih.gov/training/gatk_tutorial/vqsr.html) 
+INDEL recalibration:
+  - Mills + 1000G gold-standard indels : `Mills_and_1000G_gold_standard.indels.hg38.vcf.gz` (+ `.tbi`)
+  - Axiom Exome Plus : `Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz` (+ `.tbi`)
+  - dbSNP : `Homo_sapiens_assembly38.dbsnp138.vcf` (+ `.idx`) — re-used from the SNP set
 
-We aim to fully configure VQSR settings in the future and remove any hard-coded values, including reference data files. We are progressively adding configuration parameters for each VQSR process, but this work is not yet complete. If a parameter is not specified, it will default to the previous hard-coded value. To maintain harmonization, it is best NOT to specify the parameter or use a value equivalent to the default. Available configuration parameters involving VQSR reference data files are documented below.
+These are the standard GATK best-practices VQSR training resources. The file names and prior probabilities are configurable via `vqsr_snp_resources` and `vqsr_indel_resources` (see below) — only the defaults assume the bundle filenames above. Extra settings (tranches, annotations, max-gaussians, mode, etc.) are configured through the `vqsr_*_tranches` / `vqsr_*_annotations` parameters; the defaults are based on NIH [Biowulf](https://hpc.nih.gov/training/gatk_tutorial/vqsr.html).
 
-#### vqsr_snp_resources parameter
+#### vqsr_snp_resources / vqsr_indel_resources
 
-> **⚠️ Warning: We recommend not setting this parameter for now until all VQSR processes are configurable.**
+`vqsr_snp_resources` and `vqsr_indel_resources` specify the reference datasets used by GATK `VariantRecalibrator` to build the SNP and INDEL recalibration models, respectively. VQSR is a machine-learning approach that uses known high-confidence variants to score variant quality.
 
-The `vqsr_snp_resources` parameter is used to specify the reference datasets for Variant Quality Score Recalibration (VQSR) for SNPs. VQSR is a machine learning-based approach that uses known, high-confidence variants to build a model of variant quality. This model is then applied to the variants in your dataset to assign quality scores, which can be used to filter out low-quality variants.
+Each entry is a map with these keys:
+- `labels`: the GATK `--resource:` label string (`<name>,known=...,training=...,truth=...,prior=N`). See [GATK VariantRecalibrator documentation](https://gatk.broadinstitute.org/hc/en-us/articles/360036510892-VariantRecalibrator#--resource).
+- `vcf`: path to the training VCF (relative paths are joined with `params.broad`).
+- `index`: path to the tabix/idx file for that VCF (also relative-to-`broad`).
 
-The `vqsr_snp_resources` parameter is a list of dictionaries, each containing the following keys:
-- `labels`: A string specifying the labels for the resource. Refer to the [gatk VariantRecalibrator documentation](https://gatk.broadinstitute.org/hc/en-us/articles/360036510892-VariantRecalibrator#--resource) for a description of the expected format.
-- `vcf`: The path to the VCF file containing the reference variants.
-- `index`: The path to the index file for the VCF file.
+The defaults in `nextflow.config` are the standard GATK best-practices bundle filenames; if your reference data lives in a directory other than `params.broad`, override the lists with absolute paths.
 
-Here is an example:
+Example:
 
+```groovy
+vqsr_snp_resources = [
+    [labels: "hapmap,known=false,training=true,truth=true,prior=15",  vcf: "hapmap_3.3.hg38.vcf.gz",                       index: "hapmap_3.3.hg38.vcf.gz.tbi"],
+    [labels: "omni,known=false,training=true,truth=false,prior=12",   vcf: "1000G_omni2.5.hg38.vcf.gz",                    index: "1000G_omni2.5.hg38.vcf.gz.tbi"],
+    [labels: "1000G,known=false,training=true,truth=false,prior=10",  vcf: "1000G_phase1.snps.high_confidence.hg38.vcf.gz",index: "1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi"],
+    [labels: "dbsnp,known=true,training=false,truth=false,prior=7",   vcf: "Homo_sapiens_assembly38.dbsnp138.vcf",         index: "Homo_sapiens_assembly38.dbsnp138.vcf.idx"]
+]
+
+vqsr_indel_resources = [
+    [labels: "mills,known=false,training=true,truth=true,prior=12",      vcf: "Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",            index: "Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi"],
+    [labels: "axiomPoly,known=false,training=true,truth=false,prior=10", vcf: "Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz", index: "Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi"],
+    [labels: "dbsnp,known=true,training=false,truth=false,prior=2",      vcf: "Homo_sapiens_assembly38.dbsnp138.vcf",                        index: "Homo_sapiens_assembly38.dbsnp138.vcf.idx"]
+]
 ```
-   vqsr_snp_resources = [
-        [labels: "hapmap,known=false,training=true,truth=true,prior=15", vcf: "data-test/reference/broad/hapmap_3.3.hg38.vcf.gz", index: "data-test/reference/broad/hapmap_3.3.hg38.vcf.gz.tbi"],
-        [labels: "omni,known=false,training=true,truth=false,prior=12", vcf: "data-test/reference/broad/1000G_omni2.5.hg38.vcf.gz", index: "data-test/reference/broad/1000G_omni2.5.hg38.vcf.gz.tbi"],
-        [labels: "1000G,known=false,training=true,truth=false,prior=10", vcf: "data-test/reference/broad/1000G_phase1.snps.high_confidence.hg38.vcf.gz", index: "data-test/reference/broad/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi"],
-        [labels: "dbsnp,known=true,training=false,truth=false,prior=7", vcf: "data-test/reference/broad/Homo_sapiens_assembly38.dbsnp138.vcf", index: "data-test/reference/broad/Homo_sapiens_assembly38.dbsnp138.vcf.idx"]
-    ]
-```
+
+Tranches and annotations are tunable via `vqsr_snp_tranches`, `vqsr_snp_annotations`, `vqsr_indel_tranches`, `vqsr_indel_annotations`. `--mode`, `--max-gaussians` and `--truth-sensitivity-filter-level` (the latter controlled by `TSfilterSNP` / `TSfilterINDEL`) live in `conf/modules.config`.
 
 ## Interval file 
 The `intervalFile` parameter specifies the path to an interval file (ex: `broad/wgs_calling_regions.hg38.interval_list`).
@@ -70,12 +80,20 @@ For more details, see [Gatk documentation](https://gatk.broadinstitute.org/hc/en
 
 
 ## VEP Cache Directory
-The `vep_cache` parameter specifies the directory for the vep cache. It is only required if `vep` is specified via the
-`tools` parameter.
 
-The vep cache is not automatically populated by the pipeline. It must be pre-downloaded. You can obtain a copy of the 
-data by following the [vep installation procedure](https://github.com/Ensembl/ensembl-vep). Generally, we only need the human files obtainable from [Ensembl](https://ftp.ensembl.org/pub/release-111/variation/vep/homo_sapiens_vep_111_GRCh38.tar.gz).
-Make sure to use the data release matching the vep version used (i.e. configured docker container for the vep process).
+VEP requires a species- and version-specific cache directory. The pipeline supports two modes:
+
+**1. Use an existing cache** (default): set `vep_cache` to the directory containing the pre-downloaded cache. The cache layout must match what VEP expects — typically `<vep_cache>/<species>/<vep_cache_version>_<vep_genome>/`. Required parameters:
+
+- `vep_cache` — path to the cache root directory.
+- `vep_cache_version` — VEP cache version (e.g. `111`). Must match the version baked into the VEP container (currently `release_111.0`).
+- `vep_genome` — genome assembly (e.g. `GRCh38`).
+
+To obtain a cache manually, follow the [VEP installation procedure](https://github.com/Ensembl/ensembl-vep). For human data, the relevant tarballs live at e.g. [ftp.ensembl.org](https://ftp.ensembl.org/pub/release-111/variation/vep/homo_sapiens_vep_111_GRCh38.tar.gz). Always match the cache release to the VEP container version.
+
+**2. Download the cache from Ensembl on the fly**: set `--download_cache` to `true`. The pipeline runs the `ENSEMBLVEP_DOWNLOAD` step before VEP, which fetches the cache for the species/version/genome specified by `download_cache_species` (default `homo_sapiens`), `vep_cache_version`, and `vep_genome`. The downloaded cache is written to `outdir_cache` if set; otherwise to `${outdir}/cache/`. When `--download_cache` is enabled the locally downloaded cache is used regardless of any `vep_cache` value.
+
+The container used for downloading is a conda-based VEP image (`quay.io/biocontainers/ensembl-vep:111.0--pl5321h2a3209d_0`).
 
 ## Slivar reference data
 
@@ -129,7 +147,7 @@ cadd/1.7/
 
 To prepare the exomiser data directory, follow the instructions in the [exomiser installation documentation](https://exomiser.readthedocs.io/en/latest/installation.html#linux-install)
 
-Exomiser allows the use of a custom file for frequency data sources, typically to reduce the priority of high-frequency variants caused by artifacts. To use this feature, specify the `LOCAL` frequency source in the exomiser analysis file. Then, provide the paths to your custom frequency file and its index using the parameters `exomiser_local_frequency_path` and `exomiser_local_frequency_index_path`. Note that the index file is required if using this feature.
+Exomiser allows the use of a custom file for frequency data sources, typically to reduce the priority of high-frequency variants caused by artifacts. To use this feature, specify the `LOCAL` frequency source in the exomiser analysis file. Then, provide the path to your custom frequency file via `exomiser_local_frequency_path`. The tabix index is assumed to live alongside the file at `<path>.tbi` — if your index is somewhere else, override it via `exomiser_local_frequency_index_path`.
 
 Together with the `exomiser_data_dir` parameter, these parameters must be provided to exomiser and should match the reference data available
 - `exomiser_genome`: The genome assembly version to be used by exomiser. Accepted values are `hg38` or `hg19`.
@@ -140,7 +158,7 @@ Together with the `exomiser_data_dir` parameter, these parameters must be provid
 - `exomiser_remm_version`: The version of the REMM data to be used by exomiser (optional). Example:`0.3.1.post1`
 - `exomiser_remm_filename`: The filename of the exomiser REMM data file (optional). Example: `ReMM.v0.3.1.post1.hg38.tsv.gz`
 - `exomiser_local_frequency_path`: Path to a custom frequency source file (optional).
-- `exomiser_local_frequency_index_path`: Path to the index file (.tbi) of the custom frequency source file (optional).
+- `exomiser_local_frequency_index_path`: Optional override for the tabix index of the local frequency file. Defaults to `<exomiser_local_frequency_path>.tbi`.
 
 ## Exomiser analysis files
 In addition to the reference data, exomiser requires an analysis file (.yml/.json) that contains, among others 
@@ -167,6 +185,8 @@ analysis file should contain only the `analysis` section.
 | `dbsnpFile` | _Optional_ | Path to dbsnp file. If specified, will be used to add ids in the ID column of output vcf files. |
 | `dbsnpFileIndex` | _Optional_ | Path to dbsnp file index. Must be specified if the dbsnpFile parameter is specified. |
 | `broad` | _Optional_ | Path to the directory containing Broad reference data (for VQSR) |
+| `vqsr_snp_resources` | _Optional_ | List of `{labels, vcf, index}` maps describing the SNP VQSR training resources. Relative vcf/index paths are resolved against `params.broad`. |
+| `vqsr_indel_resources` | _Optional_ | Same shape as `vqsr_snp_resources`, used for the INDEL VQSR model. |
 | `intervalsFile` | _Optional_ | Path to the file containg the genome intervals list on which to operate |
 | `vepCache` | _Optional_ | Path to the vep cache data directory |
 | `slivar_gnomad_gnotate` | _Optional_ | Path to the gnomAD slivar gnotate (`.zip`) file. Required to apply gnomAD-based population-frequency guards in the inheritance expressions. |
@@ -183,7 +203,7 @@ analysis file should contain only the `analysis` section.
 | `exomiser_remm_version` | _Optional_ | Version of the REMM data to be used by exomiser (e.g., `0.3.1.post1`)|
 | `exomiser_remm_filename` | _Optional_	| Filename of the exomiser REMM data file (e.g., `ReMM.v0.3.1.post1.hg38.tsv.gz`) |
 | `exomiser_local_frequency_path`| _Optional_ | Path to a custom frequency source file |
-| `exomiser_local_frequency_index_path`| _Optional_ | Path to the index file (.tbi) of the custom frequency source file. Required if specifying `exomiser_local_frequency_path`. |
+| `exomiser_local_frequency_index_path`| _Optional_ | Path to the tabix index of the local frequency file. Defaults to `<exomiser_local_frequency_path>.tbi` when omitted. |
 | `exomiser_analysis_wes` | _Optional_ | Path to the exomiser analysis file for WES data, if different from the default |
 | `exomiser_analysis_wgs` | _Optional_ | Path to the exomiser analysis file for WGS data, if different from the default |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -315,6 +315,8 @@ Parameters summary
 | `dbsnpFile` | _Optional_ | Path to dbsnp file. If specified, will be used to add ids in the ID column of output vcf files. |
 | `dbsnpFileIndex` | _Optional_ | Path to dbsnp file index. Must be specified if the dbsnpFile parameter is specified. |
 | `broad` | _Optional_ | Path to the directory containing Broad reference data (for VQSR) |
+| `vqsr_snp_resources` | _Optional_ | List of `{labels, vcf, index}` maps describing the SNP VQSR training resources. Relative vcf/index paths are joined with `params.broad`. |
+| `vqsr_indel_resources` | _Optional_ | Same shape as `vqsr_snp_resources`, used for the INDEL VQSR model. |
 | `intervalsFile` | _Optional_ | Path to the file containg the genome intervals list on which to operate |
 | `tools` | _Optional_ | Additional tools to run separated by commas. Supported tools are `vep`, `exomiser`, and `slivar`. `slivar` requires `vep` to also be included. |
 | `step` | _Optional_ | Step from which to restart the pipeline. Options: `genotype`(default),`normalize`,`annotation`,`exomiser`,`inheritance` |

--- a/modules/local/exomiser/tests/main.nf.test
+++ b/modules/local/exomiser/tests/main.nf.test
@@ -1,73 +1,102 @@
 nextflow_process {
 
     name "Test Process EXOMISER"
-    script "modules/local/exomiser/main.nf"
+    script "../main.nf"
     process "EXOMISER"
 
-    // Using stub mode until we can download a test dataset and write a more elaborated test
+    // Using stub mode until we can wire up a real exomiser data-directory of manageable size.
     options "-stub"
 
     tag "local"
     tag "modules"
     tag "exomiser"
 
-    test("Test Process EXOMISER") {
-        
+    test("stub - family1") {
+
         when {
             process {
                 """
-                input[0] = [ [familyId: "family1"],
-                file("https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz"), 
-                file("https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi"), 
-                file("assets/exomiser/pheno/family1.yml"),
-                file("assets/exomiser/default_exomiser_WGS_analysis.yml")]
-                input[1] = file("data-test/reference/exomiser")
+                input[0] = [
+                    [familyId: "family1"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
+                    file("\${projectDir}/assets/exomiser/pheno/family1.yml", checkIfExists: true),
+                    file("\${projectDir}/assets/exomiser/default_exomiser_WGS_analysis.yml", checkIfExists: true)
+                ]
+                // Placeholder data-directory: stub doesn't read it, but Nextflow still stages the path.
+                input[1] = file("\${projectDir}/assets/exomiser", checkIfExists: true)
                 input[2] = "hg38"
                 input[3] = "2402"
-                input[4] = [ file("assets/exomiser/local/local_frequency_test_hg38.tsv.gz"), file("assets/exomiser/local/local_frequency_test_hg38.tsv.gz.tbi")]
+                input[4] = [
+                    file("\${projectDir}/assets/exomiser/local/local_frequency_test_hg38.tsv.gz",     checkIfExists: true),
+                    file("\${projectDir}/assets/exomiser/local/local_frequency_test_hg38.tsv.gz.tbi", checkIfExists: true)
+                ]
                 input[5] = ["1.7", "ReMM.v0.3.1.post1.hg38.tsv.gz"]
                 input[6] = ["1.3.1", "whole_genome_SNVs.tsv.gz", "gnomad.genomes.r4.0.indel.tsv.gz"]
                 """
             }
         }
-        
-        then{
 
+        then {
             def expected_meta = [familyId: "family1"]
-            with(process.out) {
-                // vcf channel
-                assert vcf.size() == 1
-                assert vcf.get(0)[0] == expected_meta
-                assert file(vcf.get(0)[1]).name == "family1.exomiser.vcf.gz"
+            assertAll(
+                { assert process.success },
+                // Verify the meta map flows through unchanged on each emit
+                { assert process.out.vcf.collect{ it[0] }         == [expected_meta] },
+                { assert process.out.tbi.collect{ it[0] }         == [expected_meta] },
+                { assert process.out.html.collect{ it[0] }        == [expected_meta] },
+                { assert process.out.json.collect{ it[0] }        == [expected_meta] },
+                { assert process.out.genetsv.collect{ it[0] }     == [expected_meta] },
+                { assert process.out.variantstsv.collect{ it[0] } == [expected_meta] },
+                // Verify the output filenames; snapshot them so any rename is loud.
+                { assert snapshot(
+                    file(process.out.vcf[0][1]).name,
+                    file(process.out.tbi[0][1]).name,
+                    file(process.out.html[0][1]).name,
+                    file(process.out.json[0][1]).name,
+                    file(process.out.genetsv[0][1]).name,
+                    file(process.out.variantstsv[0][1]).name
+                ).match() }
+                // Versions intentionally not snapshotted: the stub's `cat /EXOMISER_VERSION.txt`
+                // depends on whatever the container has baked in, which is mutable across image rebuilds.
+            )
+        }
+    }
 
-                // tbi channel
-                assert tbi.size() == 1
-                assert tbi.get(0)[0] == expected_meta
-                assert file(tbi.get(0)[1]).name == "family1.exomiser.vcf.gz.tbi"
+    test("stub - family1 - no optional reference files") {
 
-                // html channel
-                assert html.size() == 1
-                assert html.get(0)[0] == expected_meta
-                assert file(html.get(0)[1]).name == "family1.exomiser.html"
-
-                // json channel
-                assert json.size() == 1
-                assert json.get(0)[0] == expected_meta
-                assert file(json.get(0)[1]).name == "family1.exomiser.json"
-
-                // genetsv channel
-                assert genetsv.size() == 1
-                assert genetsv.get(0)[0] == expected_meta
-                assert file(genetsv.get(0)[1]).name == "family1.exomiser.genes.tsv"
-
-                // variantstsv channel
-                assert variantstsv.size() == 1
-                assert variantstsv.get(0)[0] == expected_meta
-                assert file(variantstsv.get(0)[1]).name == "family1.exomiser.variants.tsv"
-
-                // versions channel
-                // assert snapshot(versions).match()
+        when {
+            process {
+                """
+                input[0] = [
+                    [familyId: "family1"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
+                    file("\${projectDir}/assets/exomiser/pheno/family1.yml", checkIfExists: true),
+                    file("\${projectDir}/assets/exomiser/default_exomiser_WGS_analysis.yml", checkIfExists: true)
+                ]
+                input[1] = file("\${projectDir}/assets/exomiser", checkIfExists: true)
+                input[2] = "hg38"
+                input[3] = "2402"
+                // Disable local frequency, REMM, and CADD via the documented empty-placeholder forms.
+                input[4] = [[], []]
+                input[5] = ["", ""]
+                input[6] = ["", "", ""]
+                """
             }
+        }
+
+        then {
+            def expected_meta = [familyId: "family1"]
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.collect{ it[0] } == [expected_meta] },
+                { assert process.out.tbi.collect{ it[0] } == [expected_meta] },
+                { assert snapshot(
+                    file(process.out.vcf[0][1]).name,
+                    file(process.out.tbi[0][1]).name
+                ).match() }
+            )
         }
     }
 }

--- a/modules/local/exomiser/tests/main.nf.test.snap
+++ b/modules/local/exomiser/tests/main.nf.test.snap
@@ -1,0 +1,28 @@
+{
+    "stub - family1 - no optional reference files": {
+        "content": [
+            "family1.exomiser.vcf.gz",
+            "family1.exomiser.vcf.gz.tbi"
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2026-05-21T18:09:40.320925"
+    },
+    "stub - family1": {
+        "content": [
+            "family1.exomiser.vcf.gz",
+            "family1.exomiser.vcf.gz.tbi",
+            "family1.exomiser.html",
+            "family1.exomiser.json",
+            "family1.exomiser.genes.tsv",
+            "family1.exomiser.variants.tsv"
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2026-05-21T18:09:37.299757"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,6 @@
 // Global default params, used in configs
 params {
 
-    // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input                      = null
     step                       = 'genotype'
@@ -38,9 +37,9 @@ params {
     exomiser_remm_filename = null
     exomiser_analysis_wes = "${projectDir}/assets/exomiser/default_exomiser_WES_analysis.yml"
     exomiser_analysis_wgs = "${projectDir}/assets/exomiser/default_exomiser_WGS_analysis.yml"
-    exomiser_local_frequency_path = null
+    exomiser_local_frequency_path       = null
     exomiser_local_frequency_index_path = null
-    exomiser_start_from_vep = false
+    exomiser_start_from_vep             = false
 
     // Slivar options
     slivar_regions_bed   = null
@@ -300,7 +299,7 @@ process {
 		disk	=	{ check_max( 40.GB	* task.attempt, 'disk' 		)	}
 		time	=	{ check_max( 8.h	* task.attempt, 'time' 		)	}
 	}
-	withName: 'variantRecalibrator.*|apply.*' {
+	withName: 'VARIANTRECALIBRATOR.*|APPLY.*' {
 		errorStrategy = 'retry'
 		maxRetries = 2
 		cpus	=	{ check_max( 2		* task.attempt, 'cpus'		) 	}
@@ -308,7 +307,7 @@ process {
 		disk	=	{ check_max( 30.GB	* task.attempt, 'disk'		)	}
 		time	=	{ check_max( 10.h	* task.attempt, 'time'		)	}
 	}
-	withName: 'splitMultiAllelics' {
+	withName: 'SPLIT_MULTIALLELICS' {
 		errorStrategy = 'retry'
 		maxRetries = 2
 		cpus	=	{ check_max( 1		* task.attempt, 'cpus'		) 	}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -495,13 +495,13 @@
         },
         "exomiser_local_frequency_path": {
           "type": "string",
-          "description": "Path to the local frequency data file",
+          "description": "Path to the local frequency data file. The `.tbi` index is assumed to live alongside (`<path>.tbi`) unless `exomiser_local_frequency_index_path` is set explicitly.",
           "format": "file-path",
           "pattern": "^\\S+\\.tsv.gz$"
         },
         "exomiser_local_frequency_index_path": {
           "type": "string",
-          "description": "Path to the index of the local frequency data file",
+          "description": "Optional override for the tabix index of the local frequency data file. Defaults to `<exomiser_local_frequency_path>.tbi`.",
           "format": "file-path",
           "pattern": "^\\S+\\.tbi$"
         },
@@ -561,14 +561,6 @@
               "exomiser_data_dir",
               "exomiser_data_version"
             ]
-          }
-        },
-        {
-          "if": {
-            "required": ["exomiser_local_frequency_path"]
-          },
-          "then": {
-            "required": ["exomiser_local_frequency_index_path"]
           }
         }
       ]

--- a/subworkflows/local/vqsr/main.nf
+++ b/subworkflows/local/vqsr/main.nf
@@ -81,9 +81,8 @@ workflow VQSR {
 
         ch_output = GATK4_APPLYVQSR_INDEL.out.vcf
             .join(GATK4_APPLYVQSR_INDEL.out.tbi)
-            .map{ meta, vcf, tbi -> [meta, [vcf, tbi]] }
 
     emit:
-        output   = ch_output   // channel: (val(meta),  [.vcf.gz, .vcf.gz.tbi])
+        vcf_tbi   = ch_output   // channel: (val(meta), vcf, tbi)
         versions = ch_versions // channel: [ versions.yml ]
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -3,16 +3,6 @@
         "content": [
             58,
             [
-                "applyvqsrindel",
-                "applyvqsrindel/family1.snpindel.vqsr_99.vcf.gz",
-                "applyvqsrindel/family1.snpindel.vqsr_99.vcf.gz.tbi",
-                "applyvqsrindel/family4.snpindel.vqsr_99.vcf.gz",
-                "applyvqsrindel/family4.snpindel.vqsr_99.vcf.gz.tbi",
-                "applyvqsrsnp",
-                "applyvqsrsnp/family1.snp.vqsr_99.vcf.gz",
-                "applyvqsrsnp/family1.snp.vqsr_99.vcf.gz.tbi",
-                "applyvqsrsnp/family4.snp.vqsr_99.vcf.gz",
-                "applyvqsrsnp/family4.snp.vqsr_99.vcf.gz.tbi",
                 "bcftools",
                 "bcftools/family1.NA19238.filtered.vcf.gz",
                 "bcftools/family1.NA19238.filtered.vcf.gz.tbi",
@@ -89,9 +79,16 @@
                 "gatk4",
                 "gatk4/family1.genotyped.vcf.gz",
                 "gatk4/family1.genotyped.vcf.gz.tbi",
+                "gatk4/family1.indel.vqsr.recal",
+                "gatk4/family1.indel.vqsr.recal.idx",
+                "gatk4/family1.indel.vqsr.tranches",
                 "gatk4/family1.snp.vqsr.recal",
                 "gatk4/family1.snp.vqsr.recal.idx",
                 "gatk4/family1.snp.vqsr.tranches",
+                "gatk4/family1.snp.vqsr_99.vcf.gz",
+                "gatk4/family1.snp.vqsr_99.vcf.gz.tbi",
+                "gatk4/family1.snpindel.vqsr_99.vcf.gz",
+                "gatk4/family1.snpindel.vqsr_99.vcf.gz.tbi",
                 "gatk4/family2.genotyped.vcf.gz",
                 "gatk4/family2.genotyped.vcf.gz.tbi",
                 "gatk4/family2.hardfiltered.vcf.gz",
@@ -102,10 +99,18 @@
                 "gatk4/family3.hardfiltered.vcf.gz.tbi",
                 "gatk4/family4.genotyped.vcf.gz",
                 "gatk4/family4.genotyped.vcf.gz.tbi",
+                "gatk4/family4.indel.vqsr.recal",
+                "gatk4/family4.indel.vqsr.recal.idx",
+                "gatk4/family4.indel.vqsr.tranches",
                 "gatk4/family4.snp.vqsr.recal",
                 "gatk4/family4.snp.vqsr.recal.idx",
                 "gatk4/family4.snp.vqsr.tranches",
+                "gatk4/family4.snp.vqsr_99.vcf.gz",
+                "gatk4/family4.snp.vqsr_99.vcf.gz.tbi",
+                "gatk4/family4.snpindel.vqsr_99.vcf.gz",
+                "gatk4/family4.snpindel.vqsr_99.vcf.gz.tbi",
                 "pipeline_info",
+                "pipeline_info/Post-Processing-Pipeline_software_mqc_versions.yml",
                 "pipeline_info/configs",
                 "pipeline_info/configs/nextflow.config",
                 "pipeline_info/nextflow.log",
@@ -117,20 +122,13 @@
                 "slivar/variants.family1.snv.vep.slivar.vcf.gz",
                 "slivar/variants.family1.snv.vep.slivar.vcf.gz.tbi",
                 "slivar/variants.family2.snv.vep.slivar.vcf.gz",
-                "slivar/variants.family2.snv.vep.slivar.vcf.gz.tbi",
-                "variantrecalibratorindel",
-                "variantrecalibratorindel/family1.recal",
-                "variantrecalibratorindel/family1.recal.idx",
-                "variantrecalibratorindel/family1.tranches",
-                "variantrecalibratorindel/family4.recal",
-                "variantrecalibratorindel/family4.recal.idx",
-                "variantrecalibratorindel/family4.tranches"
+                "slivar/variants.family2.snv.vep.slivar.vcf.gz.tbi"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2026-05-20T18:09:11.320794"
+        "timestamp": "2026-05-22T09:24:02.371381"
     }
 }

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -5,116 +5,33 @@
 */
 
 //modules and subworkflows
-include { paramsSummaryMap        } from 'plugin/nf-validation'
-include { paramsSummaryMultiqc    } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML  } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { EXCLUDE_MNPS            } from "../subworkflows/local/exclude_mnps"
 include { VQSR                    } from "../subworkflows/local/vqsr"
 include { SLIVAR_INHERITANCE      } from '../subworkflows/local/slivar_inheritance'
-include { BCFTOOLS_VIEW           } from '../modules/nf-core/bcftools/view/main' 
+include { BCFTOOLS_VIEW           } from '../modules/nf-core/bcftools/view/main'
 include { EXOMISER                } from '../modules/local/exomiser'
-include { splitMultiAllelics      } from '../modules/local/split_multi_allelics'
-include { VCF_ANNOTATE_ENSEMBLVEP } from '../subworkflows/nf-core/vcf_annotate_ensemblvep/main'   
+include { SPLIT_MULTIALLELICS     } from '../modules/local/split_multiallelics/main'
+include { VCF_ANNOTATE_ENSEMBLVEP } from '../subworkflows/nf-core/vcf_annotate_ensemblvep/main'
 include { COMBINEGVCFS            } from '../modules/local/combine_gvcfs'
 include { GATK4_GENOTYPEGVCFS     } from '../modules/nf-core/gatk4/genotypegvcfs'
 include { GATK4_VARIANTFILTRATION } from '../modules/nf-core/gatk4/variantfiltration'
 include { ENSEMBLVEP_DOWNLOAD     } from '../modules/nf-core/ensemblvep/download/main'
-include { CHANNEL_CREATE_CSV as CHANNEL_CREATE_CSV_VEP } from '../subworkflows/local/channel_create_csv'
+include { CHANNEL_CREATE_CSV as CHANNEL_CREATE_CSV_VEP      } from '../subworkflows/local/channel_create_csv'
 include { CHANNEL_CREATE_CSV as CHANNEL_CREATE_CSV_GENOTYPE } from '../subworkflows/local/channel_create_csv'
 include { CHANNEL_CREATE_CSV as CHANNEL_CREATE_CSV_EXOMISER } from '../subworkflows/local/channel_create_csv'
 //functions
 include { isExomiserToolIncluded  } from '../subworkflows/local/utils_nfcore_postprocessing_pipeline/utils'
 include { isVepToolIncluded       } from '../subworkflows/local/utils_nfcore_postprocessing_pipeline/utils'
-include { isToolIncluded    } from '../subworkflows/local/utils_nfcore_postprocessing_pipeline/utils'
+include { isToolIncluded          } from '../subworkflows/local/utils_nfcore_postprocessing_pipeline/utils'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    RUN MAIN WORKFLOW
+    PIPELINE-LOCAL PROCESS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-/**
-Tag variants that are probable artifacts
-In the case of whole genome sequencing data, we use the vqsr procedure.
-For whole exome sequencing data, since the vqsr procedure is not supported, we use
-a hard filtering approach.
-*/
-def tagArtifacts(ch_artifact_input, hardFilters, pathFasta, pathFai, pathDict) {
-    def ch_vqsr_input = ch_artifact_input.filter{it[0].sequencingType == "WGS"}.map{ meta, vcf, tbi -> [meta, [vcf,tbi]]}
-    def ch_variantfiltration_input = ch_artifact_input.filter{it[0].sequencingType == "WES"}
-
-    def ch_vqsr_output = VQSR(ch_vqsr_input, pathFasta, pathFai, pathDict).output
-
-    def ch_gatk4_variantfiltration_output = GATK4_VARIANTFILTRATION(
-        ch_variantfiltration_input,
-        [[:], pathFasta],
-        [[:], pathFai],
-        [[:], pathDict])
-        
-    def ch_variantfiltration_output =  ch_gatk4_variantfiltration_output.vcf.join(ch_gatk4_variantfiltration_output.tbi)
-        .map{ meta, vcf, tbi -> [meta, [vcf, tbi]]}
-
-    return ch_vqsr_output.concat(ch_variantfiltration_output)
-}
-
-def exomiser(inputChannel, 
-    exomiser_genome,
-    exomiser_data_version,
-    exomiser_data_dir, 
-    analysis_wes_path, 
-    analysis_wgs_path,
-    local_frequency_file,
-    local_frequency_index_file,
-    remm_version,
-    remm_filename,
-    cadd_version,
-    cadd_snv_filename,
-    cadd_indel_filename
-    ) {
-    def ch_input_for_exomiser = inputChannel
-        .filter{ meta, vcf, tbi -> meta.familyPheno} //only run exomiser on families for which a phenopacket file is specified
-        .map{meta, vcf, tbi -> [
-            meta,
-            vcf,
-            tbi,
-            meta.familyPheno, 
-            meta.sequencingType == "WES"? file(analysis_wes_path) : file(analysis_wgs_path)
-        ]}
-    def remm_input = ["", ""]
-    if (remm_version) {
-        remm_input = [remm_version, remm_filename]
-    }
-    def cadd_input = ["", "", ""]
-    if (cadd_version) {
-        cadd_input = [cadd_version, cadd_snv_filename, cadd_indel_filename]
-    }
-
-    return EXOMISER(ch_input_for_exomiser,
-        file(exomiser_data_dir),
-        exomiser_genome,
-        exomiser_data_version,
-        [local_frequency_file, local_frequency_index_file],
-        remm_input,
-        cadd_input
-    )  
-}
-
-def vep(input_channel, vep_genome, vep_species, path_fasta, vep_cache, vep_cache_version) {
-
-    def ch_input_for_vep  = input_channel.map{meta, vcf, tbi -> [meta, vcf, []]}
-
-    return VCF_ANNOTATE_ENSEMBLVEP(
-        ch_input_for_vep,  //  meta, vcf, optional_custom_files
-        [[:], path_fasta], //  meta2, fasta
-        vep_genome,
-        vep_species,
-        vep_cache_version,
-        vep_cache,
-        [] //extra files
-    ).vcf_tbi
-}
-
-process writemeta{
+process writemeta {
 
     publishDir "${params.outdir}/pipeline_info/", mode: 'copy', overwrite: 'true'
     output:
@@ -139,29 +56,11 @@ process writemeta{
     """
 }
 
-
-def handle_mnps(input_channel, do_exclude_mnps) {
-    if(!do_exclude_mnps) {
-        return input_channel.map{meta, vcf, tbi -> [meta, [vcf, tbi]]}
-    }
-    def ch_input_excludemnps = input_channel.map{meta, vcf, tbi -> [meta, vcf]}
-    return EXCLUDE_MNPS(ch_input_excludemnps).ch_output_excludemnps
-}
-
-
-/* 
-Deal with variations in input file formats, extensions, and the presence or absence of index files.
-input: [meta, vcf]
-output: [meta, vcf, tbi]
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RUN MAIN WORKFLOW
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-def standardize_input_vcf_files(input_channel) {
-    def view_input = input_channel.map{meta,  vcf -> 
-        def tbi = file(vcf + ".tbi")
-        [meta, vcf, tbi.exists() ? tbi: []]
-    }
-    def view_output = BCFTOOLS_VIEW(view_input, [], [], [])
-    return view_output.vcf.join(view_output.tbi)
-}
 
 workflow POSTPROCESSING {
 
@@ -170,112 +69,194 @@ workflow POSTPROCESSING {
 
     main:
     //Local Temp Params
-    def referenceGenome = file(params.referenceGenome)
-    def pathReferenceGenomeFasta = file(params.referenceGenome + "/" + params.referenceGenomeFasta)
-    def pathReferenceGenomeFai = file(pathReferenceGenomeFasta + ".fai")
-    def pathIntervalFile =  params.intervalsFile? file(params.intervalsFile) : [] //The empty list is used if we don't want to use an interval file
-    def pathReferenceDict = file(params.referenceGenome + "/" + params.referenceGenomeFasta.substring(0,params.referenceGenomeFasta.indexOf(".")) + ".dict")
-    def dbsnpFile = params.dbsnpFile? file(params.dbsnpFile) : []
-    def dbsnpFileIndex = params.dbsnpFileIndex? file(params.dbsnpFileIndex) : []
-    def exomiserLocalFrequencyFile = params.exomiser_local_frequency_path? file(params.exomiser_local_frequency_path) : []
-    def exomiserLocalFrequencyIndexFile = params.exomiser_local_frequency_index_path? file(params.exomiser_local_frequency_index_path) : []
-    def slivarRegionsBed   = params.slivar_regions_bed   ? file(params.slivar_regions_bed)   : []
-    def slivarExcludeBed   = params.slivar_exclude_bed   ? file(params.slivar_exclude_bed)   : []
-    def gnomad_gnotate = params.slivar_gnomad_gnotate ? file(params.slivar_gnomad_gnotate) : []
-    def topmed_gnotate = params.slivar_topmed_gnotate ? file(params.slivar_topmed_gnotate) : []
-    def slivarGnotateFiles = [gnomad_gnotate, topmed_gnotate].findAll{ it -> it }
-    def slivarJs           = params.slivar_js            ? file(params.slivar_js)            : []
+    def pathReferenceGenomeFasta        = file(params.referenceGenome + "/" + params.referenceGenomeFasta)
+    def pathReferenceGenomeFai          = file(pathReferenceGenomeFasta + ".fai")
+    def pathIntervalFile                = params.intervalsFile ? file(params.intervalsFile) : []
+    def pathReferenceDict               = file("${params.referenceGenome}/${file(params.referenceGenomeFasta).baseName}.dict")
+    def dbsnpFile                       = params.dbsnpFile ? file(params.dbsnpFile) : []
+    def dbsnpFileIndex                  = params.dbsnpFileIndex ? file(params.dbsnpFileIndex) : []
+    def exomiserLocalFrequencyFile      = params.exomiser_local_frequency_path ? file(params.exomiser_local_frequency_path) : []
+    // Derive the index path from the local-frequency path when not explicitly provided.
+    def exomiserLocalFrequencyIndexFile = params.exomiser_local_frequency_index_path
+        ? file(params.exomiser_local_frequency_index_path)
+        : (params.exomiser_local_frequency_path ? file("${params.exomiser_local_frequency_path}.tbi") : [])
+    def slivarRegionsBed                = params.slivar_regions_bed ? file(params.slivar_regions_bed) : []
+    def slivarExcludeBed                = params.slivar_exclude_bed ? file(params.slivar_exclude_bed) : []
+    def gnomadGnotate                   = params.slivar_gnomad_gnotate ? file(params.slivar_gnomad_gnotate) : []
+    def topmedGnotate                   = params.slivar_topmed_gnotate ? file(params.slivar_topmed_gnotate) : []
+    def slivarGnotateFiles              = [gnomadGnotate, topmedGnotate].findAll{ f -> f }
+    def slivarJs                        = params.slivar_js ? file(params.slivar_js) : []
 
     def HOMO_SAPIENS_SPECIES = "homo_sapiens"
-    def cache_species = params.download_cache_species
+    def cache_species        = params.download_cache_species
 
-    file(params.outdir).mkdirs()
+    // Aggregated version YAML emitted by every called subworkflow/process; flushed at the end via softwareVersionsToYAML.
+    ch_versions = channel.empty()
 
-    ch_versions = Channel.empty()
+    // Channels that may be assigned inside `if` branches and read by later branches.
+    // Declaring them up-front makes the data-flow explicit and avoids "leaks into workflow scope".
+    ch_output_from_tagArtifacts       = channel.empty()
+    ch_output_from_splitMultiAllelics = channel.empty()
+    ch_output_from_vep                = channel.empty()
 
-    Channel
-    .fromList(workflow.configFiles)
-    .collectFile(storeDir: "${params.outdir}/pipeline_info/configs",cache: false)
+    channel
+        .fromList(workflow.configFiles)
+        .collectFile(storeDir: "${params.outdir}/pipeline_info/configs", cache: false)
 
     writemeta()
 
-
     if (params.step == 'genotype') {
-        def ch_samplesheet_standard = standardize_input_vcf_files(ch_samplesheet)
-        
-        def ch_output_from_handle_mnps = handle_mnps(ch_samplesheet_standard, params.exclude_mnps)
-            
-        def grouped_by_family = ch_output_from_handle_mnps
-            //Create groupkey for the grouptuple and separate the vcf (file[0]) and the index (files[1])
-            .map{meta, files -> tuple(groupKey(meta.familyId, meta.sampleSize),meta,files[0],files[1])}
+
+        //Standardize input VCFs: locate tbi if present, run BCFTOOLS_VIEW to normalize format/extension
+        ch_view_input = ch_samplesheet.map{ meta, vcf ->
+            def tbi = file(vcf + ".tbi")
+            [meta, vcf, tbi.exists() ? tbi : []]
+        }
+        BCFTOOLS_VIEW(ch_view_input, [], [], [])
+        ch_versions = ch_versions.mix(BCFTOOLS_VIEW.out.versions)
+        ch_vcf_tbi_standardized = BCFTOOLS_VIEW.out.vcf.join(BCFTOOLS_VIEW.out.tbi)
+
+        //Optionally drop MNPs
+        if (params.exclude_mnps) {
+            ch_input_excludemnps = ch_vcf_tbi_standardized.map{ meta, vcf, _tbi -> [meta, vcf] }
+            EXCLUDE_MNPS(ch_input_excludemnps, [[id: 'reference'], pathReferenceGenomeFasta])
+            ch_versions = ch_versions.mix(EXCLUDE_MNPS.out.versions)
+            ch_output_from_handle_mnps = EXCLUDE_MNPS.out.vcf_tbi
+        } else {
+            ch_output_from_handle_mnps = ch_vcf_tbi_standardized
+        }
+
+        ch_grouped_by_family = ch_output_from_handle_mnps
+            //Attach a familyId groupKey so groupTuple knows when each family is complete
+            .map{ meta, vcf, tbi -> tuple(groupKey(meta.familyId, meta.sampleSize), meta, vcf, tbi) }
             .groupTuple()
-            .map{ familyId, meta, vcf, tbi -> 
-            //now that samples are grouped together, we no longer follow sample in meta, and the id no longer needs the sampleId
-                def updated_meta = meta[0].findAll{!["sample", "id"].contains(it.key) }
+            .map{ _familyId, meta, vcf, tbi ->
+                //now that samples are grouped together, we no longer follow sample in meta, and the id no longer needs the sampleId
+                def updated_meta = meta[0].findAll{ entry -> !["sample", "id"].contains(entry.key) }
                 updated_meta["id"] = updated_meta.familyId
-                [updated_meta, vcf.flatten(), tbi.flatten()]}
+                [updated_meta, vcf.flatten(), tbi.flatten()]
+            }
+            //Combine per-sample gVCF files into a multi-sample gVCF file (only for families with >1 sample)
+            .branch{ meta, vcf, tbi ->
+            solo: meta.sampleSize == 1
+                return [meta, vcf, tbi]
+            family:  meta.sampleSize  > 1
+                return [meta, vcf, tbi]
+        }
+        
+        COMBINEGVCFS(ch_grouped_by_family.family, pathReferenceGenomeFasta, pathReferenceGenomeFai, pathReferenceDict, pathIntervalFile)
+        ch_versions = ch_versions.mix(COMBINEGVCFS.out.versions)
+        ch_output_from_combinegvcf = COMBINEGVCFS.out.combined_gvcf
+            .join(COMBINEGVCFS.out.tbi)
+            .mix(ch_grouped_by_family.solo)
 
-        //Combine per-sample gVCF files into a multi-sample gVCF file
-        def filtered_one = grouped_by_family.filter{it[0].sampleSize == 1}
-        def ch_input_for_combinegvcf = grouped_by_family.filter{it[0].sampleSize > 1}    
-        def ch_output_from_combinegvcf = COMBINEGVCFS(ch_input_for_combinegvcf , pathReferenceGenomeFasta,pathReferenceGenomeFai,pathReferenceDict,pathIntervalFile).combined_gvcf
-        .join(COMBINEGVCFS.out.tbi)
-        .concat(filtered_one)
+        //Perform joint genotyping on one or more samples
+        ch_input_for_genotypegvcf = ch_output_from_combinegvcf.map{ meta, vcf, tbi -> [meta, vcf, tbi, pathIntervalFile, []] }
+        GATK4_GENOTYPEGVCFS(
+            ch_input_for_genotypegvcf,
+            [[id: 'reference'], pathReferenceGenomeFasta],
+            [[id: 'reference'], pathReferenceGenomeFai],
+            [[id: 'reference'], pathReferenceDict],
+            [[id: 'dbsnp'],     dbsnpFile],
+            [[id: 'dbsnp_idx'], dbsnpFileIndex]
+        )
+        ch_versions = ch_versions.mix(GATK4_GENOTYPEGVCFS.out.versions)
+        ch_output_from_genotypegvcf = GATK4_GENOTYPEGVCFS.out.vcf.join(GATK4_GENOTYPEGVCFS.out.tbi)
 
-        //Perform joint genotyping on one or more samples  
-        def ch_input_for_genotypegvcf = ch_output_from_combinegvcf.map{meta,vcf,tbi -> [meta,vcf,tbi, pathIntervalFile, []]}
-        def ch_output_from_genotypegvcf = GATK4_GENOTYPEGVCFS(
-        ch_input_for_genotypegvcf,
-        [[:], pathReferenceGenomeFasta],
-        [[:], pathReferenceGenomeFai],
-        [[:], pathReferenceDict],
-        [[:], dbsnpFile],
-        [[:], dbsnpFileIndex]
-        ).vcf
-        .join(GATK4_GENOTYPEGVCFS.out.tbi)
+        //Tag variants that are probable artifacts.
+        //WGS data goes through VQSR; WES data is hard-filtered via GATK4_VARIANTFILTRATION.
+        ch_by_seqtype = ch_output_from_genotypegvcf.branch{ meta, vcf, tbi ->
+            wgs: meta.sequencingType == "WGS"
+                return [meta, vcf, tbi]
+            wes: meta.sequencingType == "WES"
+                return [meta, vcf, tbi]
+        }
 
-        //tag variants that are probable artifacts
-        ch_output_from_tagArtifacts = tagArtifacts(ch_output_from_genotypegvcf, params.hardFilters,pathReferenceGenomeFasta,pathReferenceGenomeFai,pathReferenceDict)
+        // Expand the user-facing VQSR resource maps into the three flat channels the subworkflow expects.
+        // VCF and index paths are resolved against params.broad.
+        def snpResources   = params.vqsr_snp_resources
+        def indelResources = params.vqsr_indel_resources
+
+        ch_snp_resource_vcfs     = snpResources.collect{ r -> file("${params.broad}/${r.vcf}") }
+        ch_snp_resource_tbis     = snpResources.collect{ r -> file("${params.broad}/${r.index}") }
+        ch_snp_resource_labels   = snpResources.collect{ r -> "--resource:${r.labels} ${file(r.vcf).getFileName()}".toString() }
+        ch_indel_resource_vcfs   = indelResources.collect{ r -> file("${params.broad}/${r.vcf}") }
+        ch_indel_resource_tbis   = indelResources.collect{ r -> file("${params.broad}/${r.index}") }
+        ch_indel_resource_labels = indelResources.collect{ r -> "--resource:${r.labels} ${file(r.vcf).getFileName()}".toString() }
+
+        VQSR(
+            ch_by_seqtype.wgs,
+            ch_snp_resource_vcfs,
+            ch_snp_resource_tbis,
+            ch_snp_resource_labels,
+            ch_indel_resource_vcfs,
+            ch_indel_resource_tbis,
+            ch_indel_resource_labels,
+            pathReferenceGenomeFasta,
+            pathReferenceGenomeFai,
+            pathReferenceDict
+        )
+        ch_versions = ch_versions.mix(VQSR.out.versions)
+
+        GATK4_VARIANTFILTRATION(
+            ch_by_seqtype.wes,
+            [[id: 'reference'], pathReferenceGenomeFasta],
+            [[id: 'reference'], pathReferenceGenomeFai],
+            [[id: 'reference'], pathReferenceDict]
+        )
+        ch_versions = ch_versions.mix(GATK4_VARIANTFILTRATION.out.versions)
+        ch_variantfiltration_output = GATK4_VARIANTFILTRATION.out.vcf
+            .join(GATK4_VARIANTFILTRATION.out.tbi)
+
+        ch_output_from_tagArtifacts = VQSR.out.vcf_tbi.mix(ch_variantfiltration_output)
     }
 
-    if ( (params.step in ['genotype', 'normalize'] ) ){
-        vcf_for_norm = params.step == 'genotype' ? ch_output_from_tagArtifacts.map{ meta, vcf_tbi -> [meta, vcf_tbi[0], vcf_tbi[1]] } : ch_samplesheet // ch_samplesheet will be the csv retrieved from outdir
+    if (params.step in ['genotype', 'normalize']) {
+        vcf_for_norm = params.step == 'genotype'
+            ? ch_output_from_tagArtifacts
+            : ch_samplesheet // ch_samplesheet will be the csv retrieved from outdir
 
         //normalize variants
-        ch_output_from_splitMultiAllelics = splitMultiAllelics(vcf_for_norm, referenceGenome)
+        SPLIT_MULTIALLELICS(vcf_for_norm, [[id: 'reference'], pathReferenceGenomeFasta])
+        ch_versions = ch_versions.mix(SPLIT_MULTIALLELICS.out.versions)
+        ch_output_from_splitMultiAllelics = SPLIT_MULTIALLELICS.out.vcf.join(SPLIT_MULTIALLELICS.out.tbi)
 
         if (params.save_genotyped || !params.tools) {
-            //create a csv file with the sample information
             CHANNEL_CREATE_CSV_GENOTYPE(ch_output_from_splitMultiAllelics, "normalized_genotypes", params.outdir, [])
         }
     }
 
-    if ( (params.step in ['genotype','normalize'] && isVepToolIncluded() ) || params.step == 'annotation' ) {
+    if ((params.step in ['genotype', 'normalize'] && isVepToolIncluded()) || params.step == 'annotation') {
 
         //Annotating variants with VEP
 
-        // Download VEP cache if download = true. Assuming we want to download even if cache provided. 
+        // Download VEP cache if download = true. Assuming we want to download even if cache provided.
         if (params.download_cache) {
-            ensemblvep_info = Channel.of([ [ id:"${params.vep_cache_version}_${params.vep_genome}" ], params.vep_genome, cache_species, params.vep_cache_version ])
+            ensemblvep_info = channel.of([ [ id: "${params.vep_cache_version}_${params.vep_genome}" ], params.vep_genome, cache_species, params.vep_cache_version ])
             ENSEMBLVEP_DOWNLOAD(ensemblvep_info)
-            vep_cache = ENSEMBLVEP_DOWNLOAD.out.cache.collect().map{ _meta, cache -> [ cache ] }
+            vep_cache = ENSEMBLVEP_DOWNLOAD.out.cache.collect().map{ _meta, cache -> [ cache ] }.first()
             ch_versions = ch_versions.mix(ENSEMBLVEP_DOWNLOAD.out.versions.first())
         } else {
             vep_cache = file(params.vep_cache)
         }
 
-        vcf_for_vep = params.step in ['genotype', 'normalize'] ? ch_output_from_splitMultiAllelics : ch_samplesheet // ch_samplesheet will be the csv retrieved from outdir
-        ch_output_from_vep = vep(
-            vcf_for_vep, 
+        vcf_for_vep = params.step in ['genotype', 'normalize']
+            ? ch_output_from_splitMultiAllelics
+            : ch_samplesheet // ch_samplesheet will be the csv retrieved from outdir
+
+        VCF_ANNOTATE_ENSEMBLVEP(
+            vcf_for_vep.map{ meta, vcf, _tbi -> [meta, vcf, []] },  // meta, vcf, optional_custom_files
+            [[id: 'reference'], pathReferenceGenomeFasta],                        // meta2, fasta
             params.vep_genome,
             HOMO_SAPIENS_SPECIES,
-            pathReferenceGenomeFasta, 
+            params.vep_cache_version,
             vep_cache,
-            params.vep_cache_version
+            []                                                       // extra files
         )
+        ch_versions = ch_versions.mix(VCF_ANNOTATE_ENSEMBLVEP.out.versions)
+        ch_output_from_vep = VCF_ANNOTATE_ENSEMBLVEP.out.vcf_tbi
 
         CHANNEL_CREATE_CSV_VEP(ch_output_from_vep, "ensemblvep", params.outdir, params.vep_outdir ?: [])
-    
     }
 
     if (isToolIncluded('slivar') || params.step == 'inheritance') {
@@ -293,32 +274,43 @@ workflow POSTPROCESSING {
         SLIVAR_INHERITANCE(ch_slivar_input, slivarRegionsBed, slivarExcludeBed, slivarGnotateFiles, slivarJs)
     }
 
-    if (isExomiserToolIncluded() || params.step == 'exomiser'){
+    if (isExomiserToolIncluded() || params.step == 'exomiser') {
 
-        if(params.exomiser_start_from_vep){
+        if (params.exomiser_start_from_vep) {
             log.info("Running the exomiser analysis using the vep annotated vcf file as input")
             ch_exomiser_input = params.step == 'exomiser' ? ch_samplesheet : ch_output_from_vep
-        }
-        else {
+        } else {
             ch_exomiser_input = params.step == 'exomiser' ? ch_samplesheet : ch_output_from_splitMultiAllelics
-        
         }
 
-        exomiser(
-            ch_exomiser_input,
+        def remm_input = params.exomiser_remm_version
+            ? [params.exomiser_remm_version, params.exomiser_remm_filename]
+            : ["", ""]
+        def cadd_input = params.exomiser_cadd_version
+            ? [params.exomiser_cadd_version, params.exomiser_cadd_snv_filename, params.exomiser_cadd_indel_filename]
+            : ["", "", ""]
+
+        // Keep only families that supplied a phenopacket; attach the right analysis YAML per sequencing type.
+        ch_input_for_exomiser = ch_exomiser_input
+            .filter{ meta, _vcf, _tbi -> meta.familyPheno }
+            .map{ meta, vcf, tbi -> [
+                meta,
+                vcf,
+                tbi,
+                meta.familyPheno,
+                meta.sequencingType == "WES" ? file(params.exomiser_analysis_wes) : file(params.exomiser_analysis_wgs)
+            ]}
+
+        EXOMISER(
+            ch_input_for_exomiser,
+            file(params.exomiser_data_dir),
             params.exomiser_genome,
             params.exomiser_data_version,
-            params.exomiser_data_dir,
-            params.exomiser_analysis_wes,
-            params.exomiser_analysis_wgs,
-            exomiserLocalFrequencyFile,
-            exomiserLocalFrequencyIndexFile,
-            params.exomiser_remm_version,
-            params.exomiser_remm_filename,
-            params.exomiser_cadd_version,
-            params.exomiser_cadd_snv_filename,
-            params.exomiser_cadd_indel_filename
+            [exomiserLocalFrequencyFile, exomiserLocalFrequencyIndexFile],
+            remm_input,
+            cadd_input
         )
+        ch_versions = ch_versions.mix(EXOMISER.out.versions)
 
         CHANNEL_CREATE_CSV_EXOMISER(
             EXOMISER.out.vcf.join(EXOMISER.out.tbi, failOnDuplicate: true, failOnMismatch: true),
@@ -326,8 +318,17 @@ workflow POSTPROCESSING {
             params.outdir,
             params.exomiser_outdir ?: []
         )
-        
     }
+
+    // Collate and write the aggregated software versions for MultiQC.
+    softwareVersionsToYAML(ch_versions)
+        .collectFile(
+            storeDir: "${params.outdir}/pipeline_info",
+            name:     'Post-Processing-Pipeline_software_mqc_versions.yml',
+            sort:     true,
+            newLine:  true
+        )
+
     emit:
     versions = ch_versions
 }

--- a/workflows/postprocessing.nf
+++ b/workflows/postprocessing.nf
@@ -105,6 +105,12 @@ workflow POSTPROCESSING {
 
     writemeta()
 
+ /*
+  ================================================================================
+       STAGE 1 — Joint genotyping (gVCFs → multi-sample VCF + artifact tagging)
+  ================================================================================
+ */
+
     if (params.step == 'genotype') {
 
         //Standardize input VCFs: locate tbi if present, run BCFTOOLS_VIEW to normalize format/extension
@@ -211,6 +217,12 @@ workflow POSTPROCESSING {
         ch_output_from_tagArtifacts = VQSR.out.vcf_tbi.mix(ch_variantfiltration_output)
     }
 
+ /*
+  ================================================================================
+       STAGE 2 — Normalization (VCF → split multi-allelics VCF)
+  ================================================================================
+ */
+
     if (params.step in ['genotype', 'normalize']) {
         vcf_for_norm = params.step == 'genotype'
             ? ch_output_from_tagArtifacts
@@ -225,6 +237,12 @@ workflow POSTPROCESSING {
             CHANNEL_CREATE_CSV_GENOTYPE(ch_output_from_splitMultiAllelics, "normalized_genotypes", params.outdir, [])
         }
     }
+
+ /*
+  ================================================================================
+       STAGE 3 — Variant annotation and prioritization (VEP, Slivar, Exomiser)
+  ================================================================================
+ */
 
     if ((params.step in ['genotype', 'normalize'] && isVepToolIncluded()) || params.step == 'annotation') {
 


### PR DESCRIPTION
<!--
# ferlab/postprocessing pull request

Many thanks for contributing to ferlab/postprocessing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
Since this repository is in construction, some of the points below regarding tests and linter might not apply yet. Make sure
to do the maximum possible.  For now, the tests are performed manually. Add a description of your tests in your pull request.
You can ask help on the [#bioinfo](https://cr-ste-justine.slack.com/archives/C074VMACUD9slack) channel.
These are the most common things requested on pull requests (PRs).
-->

### Summary
Refactors workflows/postprocessing.nf to inline the helper closures that wrapped process calls (tagArtifacts, exomiser, vep, handle_mnps, standardize_input_vcf_files), aggregates versions channels from every subworkflow, and tightens parameter handling around VQSR and the optional exomiser local-frequency index.

### Motivation
The main workflow had grown into a mix of process calls and helper functions that wrapped processes.
This PR brings the entry workflow in line with the rest of the refactor series (BIOINFO-183 / 185 / 186 / 188) so each step is plainly visible at the top level and every process contributes its versions to a single aggregated YAML.

### Changes
workflows/postprocessing.nf

* Helper closures that wrapped process calls (tagArtifacts, exomiser, vep, handle_mnps, standardize_input_vcf_files) are inlined into POSTPROCESSING. The conditional branches per --step now call processes directly.
* WES vs. WGS routing for artifact tagging is now expressed with .branch{} instead of .filter{} pairs.
* Family grouping likewise uses .branch{} to split solo vs. multi-sample families before COMBINEGVCFS.
* ch_versions is initialized once, every process/subworkflow .versions channel is mixed in, and softwareVersionsToYAML writes the aggregated Post-Processing-Pipeline_software_mqc_versions.yml to pipeline_info/.
* Channels assigned inside if branches and read by later branches (ch_output_from_tagArtifacts, ch_output_from_splitMultiAllelics, ch_output_from_vep) are pre-declared at the top of main: to make data flow explicit.
* All process inputs use proper meta maps ([[id: 'reference'], fasta], etc.) instead of [[:], ...] placeholders.
* Switched to the refactored SPLIT_MULTIALLELICS module (renamed from splitMultiAllelics) from BIOINFO-186.

exomiser
* `exomiser_local_frequency_index_path` is now optional. When omitted, the pipeline derives `<exomiser_local_frequency_path>.tbi`.

### Docs

* docs/reference_data.md rewritten to document the new VQSR resource params (SNP + INDEL), the optional exomiser local-frequency index, and the on-the-fly VEP cache download path.
* docs/usage.md and docs/output.md updated for the new params and the aggregated software-versions YAML.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ferlab/postprocessing/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint --release`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
